### PR TITLE
Add LuaJIT test suite as submodule & integrate with Travis-CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/luajit-test-cleanup"]
+	path = submodules/luajit-test-cleanup
+	url = https://github.com/luajit/luajit-test-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ sudo: false
 script:
   - make
   - src/luajit -e 'for i = 1, 1000 do end'
+  - git submodule init submodules/luajit-test-cleanup
+  - (cd submodules/luajit-test-cleanup/test; ../../../src/luajit test.lua $(seq 1 508 | grep -v 366))


### PR DESCRIPTION
Just now only 507/508 tests are executed. Test 366 fails. This also happens with LuaJIT v2.1. I need to check that with upstream on the test suite.