### PR TITLE
DCE: LJ_FASTCALL

### DIFF
--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -600,11 +600,11 @@ LJLIB_NOREG LJLIB_ASM(coroutine_wrap_aux)
 
 /* Inline declarations. */
 LJ_ASMF void lj_ff_coroutine_wrap_aux(void);
-LJ_FUNCA_NORET void LJ_FASTCALL lj_ffh_coroutine_wrap_err(lua_State *L,
+LJ_FUNCA_NORET void lj_ffh_coroutine_wrap_err(lua_State *L,
 							  lua_State *co);
 
 /* Error handler, called from assembler VM. */
-void LJ_FASTCALL lj_ffh_coroutine_wrap_err(lua_State *L, lua_State *co)
+void lj_ffh_coroutine_wrap_err(lua_State *L, lua_State *co)
 {
   co->top--; copyTV(L, L->top, co->top); L->top++;
   if (tvisstr(L->top-1))

--- a/src/lib_math.c
+++ b/src/lib_math.c
@@ -117,7 +117,7 @@ typedef union { uint64_t u64; double d; } U64double;
   r ^= z; rs->gen[i] = z;
 
 /* PRNG step function. Returns a double in the range 1.0 <= d < 2.0. */
-LJ_NOINLINE uint64_t LJ_FASTCALL lj_math_random_step(RandomState *rs)
+LJ_NOINLINE uint64_t lj_math_random_step(RandomState *rs)
 {
   uint64_t z, r = 0;
   TW223_GEN(0, 63, 31, 18)

--- a/src/lj_buf.c
+++ b/src/lj_buf.c
@@ -28,7 +28,7 @@ static void buf_grow(SBuf *sb, MSize sz)
   setmref(sb->e, b + nsz);
 }
 
-LJ_NOINLINE char *LJ_FASTCALL lj_buf_need2(SBuf *sb, MSize sz)
+LJ_NOINLINE char *lj_buf_need2(SBuf *sb, MSize sz)
 {
   lua_assert(sz > sbufsz(sb));
   if (LJ_UNLIKELY(sz > LJ_MAX_BUF))
@@ -37,7 +37,7 @@ LJ_NOINLINE char *LJ_FASTCALL lj_buf_need2(SBuf *sb, MSize sz)
   return sbufB(sb);
 }
 
-LJ_NOINLINE char *LJ_FASTCALL lj_buf_more2(SBuf *sb, MSize sz)
+LJ_NOINLINE char *lj_buf_more2(SBuf *sb, MSize sz)
 {
   MSize len = sbuflen(sb);
   lua_assert(sz > sbufleft(sb));
@@ -47,7 +47,7 @@ LJ_NOINLINE char *LJ_FASTCALL lj_buf_more2(SBuf *sb, MSize sz)
   return sbufP(sb);
 }
 
-void LJ_FASTCALL lj_buf_shrink(lua_State *L, SBuf *sb)
+void lj_buf_shrink(lua_State *L, SBuf *sb)
 {
   char *b = sbufB(sb);
   MSize osz = (MSize)(sbufE(sb) - b);
@@ -60,7 +60,7 @@ void LJ_FASTCALL lj_buf_shrink(lua_State *L, SBuf *sb)
   }
 }
 
-char * LJ_FASTCALL lj_buf_tmp(lua_State *L, MSize sz)
+char * lj_buf_tmp(lua_State *L, MSize sz)
 {
   SBuf *sb = &G(L)->tmpbuf;
   setsbufL(sb, L);
@@ -77,7 +77,7 @@ SBuf *lj_buf_putmem(SBuf *sb, const void *q, MSize len)
   return sb;
 }
 
-SBuf * LJ_FASTCALL lj_buf_putchar(SBuf *sb, int c)
+SBuf * lj_buf_putchar(SBuf *sb, int c)
 {
   char *p = lj_buf_more(sb, 1);
   *p++ = (char)c;
@@ -85,7 +85,7 @@ SBuf * LJ_FASTCALL lj_buf_putchar(SBuf *sb, int c)
   return sb;
 }
 
-SBuf * LJ_FASTCALL lj_buf_putstr(SBuf *sb, GCstr *s)
+SBuf * lj_buf_putstr(SBuf *sb, GCstr *s)
 {
   MSize len = s->len;
   char *p = lj_buf_more(sb, len);
@@ -96,7 +96,7 @@ SBuf * LJ_FASTCALL lj_buf_putstr(SBuf *sb, GCstr *s)
 
 /* -- High-level buffer put operations ------------------------------------ */
 
-SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s)
+SBuf * lj_buf_putstr_reverse(SBuf *sb, GCstr *s)
 {
   MSize len = s->len;
   char *p = lj_buf_more(sb, len), *e = p+len;
@@ -107,7 +107,7 @@ SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s)
   return sb;
 }
 
-SBuf * LJ_FASTCALL lj_buf_putstr_lower(SBuf *sb, GCstr *s)
+SBuf * lj_buf_putstr_lower(SBuf *sb, GCstr *s)
 {
   MSize len = s->len;
   char *p = lj_buf_more(sb, len), *e = p+len;
@@ -121,7 +121,7 @@ SBuf * LJ_FASTCALL lj_buf_putstr_lower(SBuf *sb, GCstr *s)
   return sb;
 }
 
-SBuf * LJ_FASTCALL lj_buf_putstr_upper(SBuf *sb, GCstr *s)
+SBuf * lj_buf_putstr_upper(SBuf *sb, GCstr *s)
 {
   MSize len = s->len;
   char *p = lj_buf_more(sb, len), *e = p+len;
@@ -193,7 +193,7 @@ SBuf *lj_buf_puttab(SBuf *sb, GCtab *t, GCstr *sep, int32_t i, int32_t e)
 
 /* -- Miscellaneous buffer operations ------------------------------------- */
 
-GCstr * LJ_FASTCALL lj_buf_tostr(SBuf *sb)
+GCstr * lj_buf_tostr(SBuf *sb)
 {
   return lj_str_new(sbufL(sb), sbufB(sb), sbuflen(sb));
 }
@@ -209,7 +209,7 @@ GCstr *lj_buf_cat2str(lua_State *L, GCstr *s1, GCstr *s2)
 }
 
 /* Read ULEB128 from buffer. */
-uint32_t LJ_FASTCALL lj_buf_ruleb128(const char **pp)
+uint32_t lj_buf_ruleb128(const char **pp)
 {
   const uint8_t *p = (const uint8_t *)*pp;
   uint32_t v = *p++;

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -22,10 +22,10 @@
 #define setsbufL(sb, l)	(setmref((sb)->L, (l)))
 
 /* Buffer management */
-LJ_FUNC char *LJ_FASTCALL lj_buf_need2(SBuf *sb, MSize sz);
-LJ_FUNC char *LJ_FASTCALL lj_buf_more2(SBuf *sb, MSize sz);
-LJ_FUNC void LJ_FASTCALL lj_buf_shrink(lua_State *L, SBuf *sb);
-LJ_FUNC char * LJ_FASTCALL lj_buf_tmp(lua_State *L, MSize sz);
+LJ_FUNC char *lj_buf_need2(SBuf *sb, MSize sz);
+LJ_FUNC char *lj_buf_more2(SBuf *sb, MSize sz);
+LJ_FUNC void lj_buf_shrink(lua_State *L, SBuf *sb);
+LJ_FUNC char * lj_buf_tmp(lua_State *L, MSize sz);
 
 static LJ_AINLINE void lj_buf_init(lua_State *L, SBuf *sb)
 {
@@ -67,8 +67,8 @@ static LJ_AINLINE char *lj_buf_more(SBuf *sb, MSize sz)
 
 /* Low-level buffer put operations */
 LJ_FUNC SBuf *lj_buf_putmem(SBuf *sb, const void *q, MSize len);
-LJ_FUNC SBuf * LJ_FASTCALL lj_buf_putchar(SBuf *sb, int c);
-LJ_FUNC SBuf * LJ_FASTCALL lj_buf_putstr(SBuf *sb, GCstr *s);
+LJ_FUNC SBuf * lj_buf_putchar(SBuf *sb, int c);
+LJ_FUNC SBuf * lj_buf_putstr(SBuf *sb, GCstr *s);
 
 static LJ_AINLINE char *lj_buf_wmem(char *p, const void *q, MSize len)
 {
@@ -83,17 +83,17 @@ static LJ_AINLINE void lj_buf_putb(SBuf *sb, int c)
 }
 
 /* High-level buffer put operations */
-LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s);
-LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_lower(SBuf *sb, GCstr *s);
-LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_upper(SBuf *sb, GCstr *s);
+LJ_FUNCA SBuf * lj_buf_putstr_reverse(SBuf *sb, GCstr *s);
+LJ_FUNCA SBuf * lj_buf_putstr_lower(SBuf *sb, GCstr *s);
+LJ_FUNCA SBuf * lj_buf_putstr_upper(SBuf *sb, GCstr *s);
 LJ_FUNC SBuf *lj_buf_putstr_rep(SBuf *sb, GCstr *s, int32_t rep);
 LJ_FUNC SBuf *lj_buf_puttab(SBuf *sb, GCtab *t, GCstr *sep,
 			    int32_t i, int32_t e);
 
 /* Miscellaneous buffer operations */
-LJ_FUNCA GCstr * LJ_FASTCALL lj_buf_tostr(SBuf *sb);
+LJ_FUNCA GCstr * lj_buf_tostr(SBuf *sb);
 LJ_FUNC GCstr *lj_buf_cat2str(lua_State *L, GCstr *s1, GCstr *s2);
-LJ_FUNC uint32_t LJ_FASTCALL lj_buf_ruleb128(const char **pp);
+LJ_FUNC uint32_t lj_buf_ruleb128(const char **pp);
 
 static LJ_AINLINE GCstr *lj_buf_str(lua_State *L, SBuf *sb)
 {

--- a/src/lj_ccall.h
+++ b/src/lj_ccall.h
@@ -77,7 +77,7 @@ typedef LJ_ALIGN(CCALL_ALIGN_CALLSTATE) struct CCallState {
 /* -- C call handling ----------------------------------------------------- */
 
 /* Really belongs to lj_vm.h. */
-LJ_ASMF void LJ_FASTCALL lj_vm_ffi_call(CCallState *cc);
+LJ_ASMF void lj_vm_ffi_call(CCallState *cc);
 
 LJ_FUNC CTypeID lj_ccall_ctid_vararg(CTState *cts, cTValue *o);
 LJ_FUNC int lj_ccall_func(lua_State *L, GCcdata *cd);

--- a/src/lj_ccallback.c
+++ b/src/lj_ccallback.c
@@ -259,7 +259,7 @@ static void callback_conv_result(CTState *cts, lua_State *L, TValue *o)
 }
 
 /* Enter callback. */
-lua_State * LJ_FASTCALL lj_ccallback_enter(CTState *cts, void *cf)
+lua_State * lj_ccallback_enter(CTState *cts, void *cf)
 {
   lua_State *L = cts->L;
   global_State *g = cts->g;
@@ -281,7 +281,7 @@ lua_State * LJ_FASTCALL lj_ccallback_enter(CTState *cts, void *cf)
 }
 
 /* Leave callback. */
-void LJ_FASTCALL lj_ccallback_leave(CTState *cts, TValue *o)
+void lj_ccallback_leave(CTState *cts, TValue *o)
 {
   lua_State *L = cts->L;
   GCfunc *fn;

--- a/src/lj_ccallback.h
+++ b/src/lj_ccallback.h
@@ -14,8 +14,8 @@
 LJ_ASMF void lj_vm_ffi_callback(void);
 
 LJ_FUNC MSize lj_ccallback_ptr2slot(CTState *cts, void *p);
-LJ_FUNCA lua_State * LJ_FASTCALL lj_ccallback_enter(CTState *cts, void *cf);
-LJ_FUNCA void LJ_FASTCALL lj_ccallback_leave(CTState *cts, TValue *o);
+LJ_FUNCA lua_State * lj_ccallback_enter(CTState *cts, void *cf);
+LJ_FUNCA void lj_ccallback_leave(CTState *cts, TValue *o);
 LJ_FUNC void *lj_ccallback_new(CTState *cts, CType *ct, GCfunc *fn);
 LJ_FUNC void lj_ccallback_mcode_free(CTState *cts);
 

--- a/src/lj_cdata.c
+++ b/src/lj_cdata.c
@@ -58,7 +58,7 @@ GCcdata *lj_cdata_newx(CTState *cts, CTypeID id, CTSize sz, CTInfo info)
 }
 
 /* Free a C data object. */
-void LJ_FASTCALL lj_cdata_free(global_State *g, GCcdata *cd)
+void lj_cdata_free(global_State *g, GCcdata *cd)
 {
   if (LJ_UNLIKELY(cd->marked & LJ_GC_CDATA_FIN)) {
     GCobj *root;

--- a/src/lj_cdata.h
+++ b/src/lj_cdata.h
@@ -62,7 +62,7 @@ LJ_FUNC GCcdata *lj_cdata_newv(lua_State *L, CTypeID id, CTSize sz,
 LJ_FUNC GCcdata *lj_cdata_newx(CTState *cts, CTypeID id, CTSize sz,
 			       CTInfo info);
 
-LJ_FUNC void LJ_FASTCALL lj_cdata_free(global_State *g, GCcdata *cd);
+LJ_FUNC void lj_cdata_free(global_State *g, GCcdata *cd);
 LJ_FUNC void lj_cdata_setfin(lua_State *L, GCcdata *cd, GCobj *obj,
 			     uint32_t it);
 

--- a/src/lj_crecord.c
+++ b/src/lj_crecord.c
@@ -738,7 +738,7 @@ static void crec_index_meta(jit_State *J, CTState *cts, CType *ct,
   }
 }
 
-void LJ_FASTCALL recff_cdata_index(jit_State *J, RecordFFData *rd)
+void recff_cdata_index(jit_State *J, RecordFFData *rd)
 {
   TRef idx, ptr = J->base[0];
   ptrdiff_t ofs = sizeof(GCcdata);
@@ -1147,7 +1147,7 @@ static int crec_call(jit_State *J, RecordFFData *rd, GCcdata *cd)
   return 0;
 }
 
-void LJ_FASTCALL recff_cdata_call(jit_State *J, RecordFFData *rd)
+void recff_cdata_call(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   GCcdata *cd = argv2cdata(J, J->base[0], &rd->argv[0]);
@@ -1323,7 +1323,7 @@ static TRef crec_arith_meta(jit_State *J, TRef *sp, CType **s, CTState *cts,
   return 0;
 }
 
-void LJ_FASTCALL recff_cdata_arith(jit_State *J, RecordFFData *rd)
+void recff_cdata_arith(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   TRef sp[2];
@@ -1425,7 +1425,7 @@ void LJ_FASTCALL recff_cdata_arith(jit_State *J, RecordFFData *rd)
 
 /* -- C library namespace metamethods ------------------------------------- */
 
-void LJ_FASTCALL recff_clib_index(jit_State *J, RecordFFData *rd)
+void recff_clib_index(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   if (tref_isudata(J->base[0]) && tref_isstr(J->base[1]) &&
@@ -1476,12 +1476,12 @@ static TRef crec_toint(jit_State *J, CTState *cts, TRef sp, TValue *sval)
   return crec_ct_tv(J, ctype_get(cts, CTID_INT32), 0, sp, sval);
 }
 
-void LJ_FASTCALL recff_ffi_new(jit_State *J, RecordFFData *rd)
+void recff_ffi_new(jit_State *J, RecordFFData *rd)
 {
   crec_alloc(J, rd, argv2ctype(J, J->base[0], &rd->argv[0]));
 }
 
-void LJ_FASTCALL recff_ffi_errno(jit_State *J, RecordFFData *rd)
+void recff_ffi_errno(jit_State *J, RecordFFData *rd)
 {
   UNUSED(rd);
   if (J->base[0])
@@ -1489,7 +1489,7 @@ void LJ_FASTCALL recff_ffi_errno(jit_State *J, RecordFFData *rd)
   J->base[0] = lj_ir_call(J, IRCALL_lj_vm_errno);
 }
 
-void LJ_FASTCALL recff_ffi_string(jit_State *J, RecordFFData *rd)
+void recff_ffi_string(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   TRef tr = J->base[0];
@@ -1506,7 +1506,7 @@ void LJ_FASTCALL recff_ffi_string(jit_State *J, RecordFFData *rd)
   }  /* else: interpreter will throw. */
 }
 
-void LJ_FASTCALL recff_ffi_copy(jit_State *J, RecordFFData *rd)
+void recff_ffi_copy(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   TRef trdst = J->base[0], trsrc = J->base[1], trlen = J->base[2];
@@ -1524,7 +1524,7 @@ void LJ_FASTCALL recff_ffi_copy(jit_State *J, RecordFFData *rd)
   }  /* else: interpreter will throw. */
 }
 
-void LJ_FASTCALL recff_ffi_fill(jit_State *J, RecordFFData *rd)
+void recff_ffi_fill(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   TRef trdst = J->base[0], trlen = J->base[1], trfill = J->base[2];
@@ -1548,7 +1548,7 @@ void LJ_FASTCALL recff_ffi_fill(jit_State *J, RecordFFData *rd)
   }  /* else: interpreter will throw. */
 }
 
-void LJ_FASTCALL recff_ffi_typeof(jit_State *J, RecordFFData *rd)
+void recff_ffi_typeof(jit_State *J, RecordFFData *rd)
 {
   if (tref_iscdata(J->base[0])) {
     TRef trid = lj_ir_kint(J, argv2ctype(J, J->base[0], &rd->argv[0]));
@@ -1560,7 +1560,7 @@ void LJ_FASTCALL recff_ffi_typeof(jit_State *J, RecordFFData *rd)
   }
 }
 
-void LJ_FASTCALL recff_ffi_istype(jit_State *J, RecordFFData *rd)
+void recff_ffi_istype(jit_State *J, RecordFFData *rd)
 {
   argv2ctype(J, J->base[0], &rd->argv[0]);
   if (tref_iscdata(J->base[1])) {
@@ -1572,7 +1572,7 @@ void LJ_FASTCALL recff_ffi_istype(jit_State *J, RecordFFData *rd)
   }
 }
 
-void LJ_FASTCALL recff_ffi_abi(jit_State *J, RecordFFData *rd)
+void recff_ffi_abi(jit_State *J, RecordFFData *rd)
 {
   if (tref_isstr(J->base[0])) {
     /* Specialize to the ABI string to make the boolean result a constant. */
@@ -1585,7 +1585,7 @@ void LJ_FASTCALL recff_ffi_abi(jit_State *J, RecordFFData *rd)
 }
 
 /* Record ffi.sizeof(), ffi.alignof(), ffi.offsetof(). */
-void LJ_FASTCALL recff_ffi_xof(jit_State *J, RecordFFData *rd)
+void recff_ffi_xof(jit_State *J, RecordFFData *rd)
 {
   CTypeID id = argv2ctype(J, J->base[0], &rd->argv[0]);
   if (rd->data == FF_ffi_sizeof) {
@@ -1602,7 +1602,7 @@ void LJ_FASTCALL recff_ffi_xof(jit_State *J, RecordFFData *rd)
   J->base[0] = J->base[1] = J->base[2] = TREF_NIL;
 }
 
-void LJ_FASTCALL recff_ffi_gc(jit_State *J, RecordFFData *rd)
+void recff_ffi_gc(jit_State *J, RecordFFData *rd)
 {
   argv2cdata(J, J->base[0], &rd->argv[0]);
   if (!J->base[1])
@@ -1626,7 +1626,7 @@ static CTypeID crec_bit64_type(CTState *cts, cTValue *tv)
   return 0;  /* Use regular 32 bit ops. */
 }
 
-void LJ_FASTCALL recff_bit64_tobit(jit_State *J, RecordFFData *rd)
+void recff_bit64_tobit(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   TRef tr = crec_ct_tv(J, ctype_get(cts, CTID_INT64), 0,
@@ -1636,7 +1636,7 @@ void LJ_FASTCALL recff_bit64_tobit(jit_State *J, RecordFFData *rd)
   J->base[0] = tr;
 }
 
-int LJ_FASTCALL recff_bit64_unary(jit_State *J, RecordFFData *rd)
+int recff_bit64_unary(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   CTypeID id = crec_bit64_type(cts, &rd->argv[0]);
@@ -1649,7 +1649,7 @@ int LJ_FASTCALL recff_bit64_unary(jit_State *J, RecordFFData *rd)
   return 0;
 }
 
-int LJ_FASTCALL recff_bit64_nary(jit_State *J, RecordFFData *rd)
+int recff_bit64_nary(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   CTypeID id = 0;
@@ -1672,7 +1672,7 @@ int LJ_FASTCALL recff_bit64_nary(jit_State *J, RecordFFData *rd)
   return 0;
 }
 
-int LJ_FASTCALL recff_bit64_shift(jit_State *J, RecordFFData *rd)
+int recff_bit64_shift(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   CTypeID id;
@@ -1742,7 +1742,7 @@ TRef recff_bit64_tohex(jit_State *J, RecordFFData *rd, TRef hdr)
 
 /* -- Miscellaneous library functions ------------------------------------- */
 
-void LJ_FASTCALL lj_crecord_tonumber(jit_State *J, RecordFFData *rd)
+void lj_crecord_tonumber(jit_State *J, RecordFFData *rd)
 {
   CTState *cts = ctype_ctsG(J2G(J));
   CType *d, *ct = lj_ctype_rawref(cts, cdataV(&rd->argv[0])->ctypeid);

--- a/src/lj_crecord.h
+++ b/src/lj_crecord.h
@@ -10,27 +10,27 @@
 #include "lj_jit.h"
 #include "lj_ffrecord.h"
 
-LJ_FUNC void LJ_FASTCALL recff_cdata_index(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_cdata_call(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_cdata_arith(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_clib_index(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_new(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_errno(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_string(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_copy(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_fill(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_typeof(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_istype(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_abi(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_xof(jit_State *J, RecordFFData *rd);
-LJ_FUNC void LJ_FASTCALL recff_ffi_gc(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_cdata_index(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_cdata_call(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_cdata_arith(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_clib_index(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_new(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_errno(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_string(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_copy(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_fill(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_typeof(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_istype(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_abi(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_xof(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_ffi_gc(jit_State *J, RecordFFData *rd);
 
-LJ_FUNC void LJ_FASTCALL recff_bit64_tobit(jit_State *J, RecordFFData *rd);
-LJ_FUNC int LJ_FASTCALL recff_bit64_unary(jit_State *J, RecordFFData *rd);
-LJ_FUNC int LJ_FASTCALL recff_bit64_nary(jit_State *J, RecordFFData *rd);
-LJ_FUNC int LJ_FASTCALL recff_bit64_shift(jit_State *J, RecordFFData *rd);
+LJ_FUNC void recff_bit64_tobit(jit_State *J, RecordFFData *rd);
+LJ_FUNC int recff_bit64_unary(jit_State *J, RecordFFData *rd);
+LJ_FUNC int recff_bit64_nary(jit_State *J, RecordFFData *rd);
+LJ_FUNC int recff_bit64_shift(jit_State *J, RecordFFData *rd);
 LJ_FUNC TRef recff_bit64_tohex(jit_State *J, RecordFFData *rd, TRef hdr);
 
-LJ_FUNC void LJ_FASTCALL lj_crecord_tonumber(jit_State *J, RecordFFData *rd);
+LJ_FUNC void lj_crecord_tonumber(jit_State *J, RecordFFData *rd);
 
 #endif

--- a/src/lj_debug.c
+++ b/src/lj_debug.c
@@ -106,7 +106,7 @@ static BCPos debug_framepc(lua_State *L, GCfunc *fn, cTValue *nextframe)
 /* -- Line numbers -------------------------------------------------------- */
 
 /* Get line number for a bytecode position. */
-BCLine LJ_FASTCALL lj_debug_line(GCproto *pt, BCPos pc)
+BCLine lj_debug_line(GCproto *pt, BCPos pc)
 {
   const void *lineinfo = proto_lineinfo(pt);
   if (pc <= pt->sizebc && lineinfo) {

--- a/src/lj_debug.h
+++ b/src/lj_debug.h
@@ -27,7 +27,7 @@ typedef struct lj_Debug {
 } lj_Debug;
 
 LJ_FUNC cTValue *lj_debug_frame(lua_State *L, int level, int *size);
-LJ_FUNC BCLine LJ_FASTCALL lj_debug_line(GCproto *pt, BCPos pc);
+LJ_FUNC BCLine lj_debug_line(GCproto *pt, BCPos pc);
 LJ_FUNC const char *lj_debug_uvname(GCproto *pt, uint32_t idx);
 LJ_FUNC const char *lj_debug_uvnamev(cTValue *o, uint32_t idx, TValue **tvp);
 LJ_FUNC const char *lj_debug_slotname(GCproto *pt, const BCIns *pc,

--- a/src/lj_def.h
+++ b/src/lj_def.h
@@ -180,9 +180,6 @@ static LJ_AINLINE uint32_t lj_getu32(const void *p)
 #endif
 
 /* Optional defines. */
-#ifndef LJ_FASTCALL
-#define LJ_FASTCALL
-#endif
 #ifndef LJ_NORET
 #define LJ_NORET
 #endif

--- a/src/lj_dispatch.c
+++ b/src/lj_dispatch.c
@@ -339,7 +339,7 @@ static BCReg cur_topslot(GCproto *pt, const BCIns *pc, uint32_t nres)
 }
 
 /* Instruction dispatch. Used by instr/line/return hooks or when recording. */
-void LJ_FASTCALL lj_dispatch_ins(lua_State *L, const BCIns *pc)
+void lj_dispatch_ins(lua_State *L, const BCIns *pc)
 {
   ERRNO_SAVE
   GCfunc *fn = curr_func(L);
@@ -400,7 +400,7 @@ static int call_init(lua_State *L, GCfunc *fn)
 }
 
 /* Call dispatch. Used by call hooks, hot calls or when recording. */
-ASMFunction LJ_FASTCALL lj_dispatch_call(lua_State *L, const BCIns *pc)
+ASMFunction lj_dispatch_call(lua_State *L, const BCIns *pc)
 {
   ERRNO_SAVE
   GCfunc *fn = curr_func(L);
@@ -446,7 +446,7 @@ out:
 }
 
 /* Stitch a new trace. */
-void LJ_FASTCALL lj_dispatch_stitch(jit_State *J, const BCIns *pc)
+void lj_dispatch_stitch(jit_State *J, const BCIns *pc)
 {
   ERRNO_SAVE
   lua_State *L = J->L;

--- a/src/lj_dispatch.h
+++ b/src/lj_dispatch.h
@@ -65,9 +65,9 @@ LJ_FUNC void lj_dispatch_init_hotcount(global_State *g);
 LJ_FUNC void lj_dispatch_update(global_State *g);
 
 /* Instruction dispatch callback for hooks or when recording. */
-LJ_FUNCA void LJ_FASTCALL lj_dispatch_ins(lua_State *L, const BCIns *pc);
-LJ_FUNCA ASMFunction LJ_FASTCALL lj_dispatch_call(lua_State *L, const BCIns*pc);
-LJ_FUNCA void LJ_FASTCALL lj_dispatch_stitch(jit_State *J, const BCIns *pc);
+LJ_FUNCA void lj_dispatch_ins(lua_State *L, const BCIns *pc);
+LJ_FUNCA ASMFunction lj_dispatch_call(lua_State *L, const BCIns*pc);
+LJ_FUNCA void lj_dispatch_stitch(jit_State *J, const BCIns *pc);
 
 #if LJ_HASFFI && !defined(_BUILDVM_H)
 /* Save/restore errno and GetLastError() around hooks, exits and recording. */

--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -303,7 +303,7 @@ static void err_raise_ext(int errcode)
 /* -- Error handling ------------------------------------------------------ */
 
 /* Throw error. Find catch frame, unwind stack and continue. */
-LJ_NOINLINE void LJ_FASTCALL lj_err_throw(lua_State *L, int errcode)
+LJ_NOINLINE void lj_err_throw(lua_State *L, int errcode)
 {
   global_State *g = G(L);
   lj_trace_abort(g);

--- a/src/lj_err.h
+++ b/src/lj_err.h
@@ -21,7 +21,7 @@ LJ_DATA const char *lj_err_allmsg;
 #define err2msg(em)	(lj_err_allmsg+(int)(em))
 
 LJ_FUNC GCstr *lj_err_str(lua_State *L, ErrMsg em);
-LJ_FUNCA_NORET void LJ_FASTCALL lj_err_throw(lua_State *L, int errcode);
+LJ_FUNCA_NORET void lj_err_throw(lua_State *L, int errcode);
 LJ_FUNC_NORET void lj_err_mem(lua_State *L);
 LJ_FUNC_NORET void lj_err_run(lua_State *L);
 LJ_FUNC_NORET void lj_err_msg(lua_State *L, ErrMsg em);

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -60,7 +60,7 @@
 */
 
 /* Type of handler to record a fast function. */
-typedef void (LJ_FASTCALL *RecordFunc)(jit_State *J, RecordFFData *rd);
+typedef void (*RecordFunc)(jit_State *J, RecordFFData *rd);
 
 /* Get runtime value of int argument. */
 static int32_t argv2int(jit_State *J, TValue *o)
@@ -135,7 +135,7 @@ static void recff_stitch(jit_State *J)
 }
 
 /* Fallback handler for fast functions that are not recorded (yet). */
-static void LJ_FASTCALL recff_nyi(jit_State *J, RecordFFData *rd)
+static void recff_nyi(jit_State *J, RecordFFData *rd)
 {
   if (J->cur.nins < (IRRef)J->param[JIT_P_minstitch] + REF_BASE) {
     lj_trace_err_info(J, LJ_TRERR_TRACEUV);
@@ -179,13 +179,13 @@ static TRef recff_bufhdr(jit_State *J)
 
 /* -- Base library fast functions ----------------------------------------- */
 
-static void LJ_FASTCALL recff_assert(jit_State *J, RecordFFData *rd)
+static void recff_assert(jit_State *J, RecordFFData *rd)
 {
   /* Arguments already specialized. The interpreter throws for nil/false. */
   rd->nres = J->maxslot;  /* Pass through all arguments. */
 }
 
-static void LJ_FASTCALL recff_type(jit_State *J, RecordFFData *rd)
+static void recff_type(jit_State *J, RecordFFData *rd)
 {
   /* Arguments already specialized. Result is a constant string. Neat, huh? */
   uint32_t t;
@@ -199,7 +199,7 @@ static void LJ_FASTCALL recff_type(jit_State *J, RecordFFData *rd)
   UNUSED(rd);
 }
 
-static void LJ_FASTCALL recff_getmetatable(jit_State *J, RecordFFData *rd)
+static void recff_getmetatable(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tr) {
@@ -213,7 +213,7 @@ static void LJ_FASTCALL recff_getmetatable(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_setmetatable(jit_State *J, RecordFFData *rd)
+static void recff_setmetatable(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   TRef mt = J->base[1];
@@ -233,7 +233,7 @@ static void LJ_FASTCALL recff_setmetatable(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_rawget(jit_State *J, RecordFFData *rd)
+static void recff_rawget(jit_State *J, RecordFFData *rd)
 {
   RecordIndex ix;
   ix.tab = J->base[0]; ix.key = J->base[1];
@@ -245,7 +245,7 @@ static void LJ_FASTCALL recff_rawget(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_rawset(jit_State *J, RecordFFData *rd)
+static void recff_rawset(jit_State *J, RecordFFData *rd)
 {
   RecordIndex ix;
   ix.tab = J->base[0]; ix.key = J->base[1]; ix.val = J->base[2];
@@ -259,7 +259,7 @@ static void LJ_FASTCALL recff_rawset(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_rawequal(jit_State *J, RecordFFData *rd)
+static void recff_rawequal(jit_State *J, RecordFFData *rd)
 {
   TRef tra = J->base[0];
   TRef trb = J->base[1];
@@ -270,7 +270,7 @@ static void LJ_FASTCALL recff_rawequal(jit_State *J, RecordFFData *rd)
 }
 
 #if LJ_52
-static void LJ_FASTCALL recff_rawlen(jit_State *J, RecordFFData *rd)
+static void recff_rawlen(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tref_isstr(tr))
@@ -301,7 +301,7 @@ int32_t lj_ffrecord_select_mode(jit_State *J, TRef tr, TValue *tv)
   }
 }
 
-static void LJ_FASTCALL recff_select(jit_State *J, RecordFFData *rd)
+static void recff_select(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tr) {
@@ -325,7 +325,7 @@ static void LJ_FASTCALL recff_select(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_tonumber(jit_State *J, RecordFFData *rd)
+static void recff_tonumber(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   TRef base = J->base[1];
@@ -389,7 +389,7 @@ static int recff_metacall(jit_State *J, RecordFFData *rd, MMS mm)
   return 0;
 }
 
-static void LJ_FASTCALL recff_tostring(jit_State *J, RecordFFData *rd)
+static void recff_tostring(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tref_isstr(tr)) {
@@ -408,7 +408,7 @@ static void LJ_FASTCALL recff_tostring(jit_State *J, RecordFFData *rd)
   }
 }
 
-static void LJ_FASTCALL recff_ipairs_aux(jit_State *J, RecordFFData *rd)
+static void recff_ipairs_aux(jit_State *J, RecordFFData *rd)
 {
   RecordIndex ix;
   ix.tab = J->base[0];
@@ -425,7 +425,7 @@ static void LJ_FASTCALL recff_ipairs_aux(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_xpairs(jit_State *J, RecordFFData *rd)
+static void recff_xpairs(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (!((LJ_52 || (LJ_HASFFI && tref_iscdata(tr))) &&
@@ -439,7 +439,7 @@ static void LJ_FASTCALL recff_xpairs(jit_State *J, RecordFFData *rd)
   }
 }
 
-static void LJ_FASTCALL recff_pcall(jit_State *J, RecordFFData *rd)
+static void recff_pcall(jit_State *J, RecordFFData *rd)
 {
   if (J->maxslot >= 1) {
     /* Shift function arguments up. */
@@ -457,7 +457,7 @@ static TValue *recff_xpcall_cp(lua_State *L, lua_CFunction dummy, void *ud)
   return NULL;
 }
 
-static void LJ_FASTCALL recff_xpcall(jit_State *J, RecordFFData *rd)
+static void recff_xpcall(jit_State *J, RecordFFData *rd)
 {
   if (J->maxslot >= 2) {
     TValue argv0, argv1;
@@ -482,7 +482,7 @@ static void LJ_FASTCALL recff_xpcall(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_getfenv(jit_State *J, RecordFFData *rd)
+static void recff_getfenv(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   /* Only support getfenv(0) for now. */
@@ -496,7 +496,7 @@ static void LJ_FASTCALL recff_getfenv(jit_State *J, RecordFFData *rd)
 
 /* -- Math library fast functions ----------------------------------------- */
 
-static void LJ_FASTCALL recff_math_abs(jit_State *J, RecordFFData *rd)
+static void recff_math_abs(jit_State *J, RecordFFData *rd)
 {
   TRef tr = lj_ir_tonum(J, J->base[0]);
   J->base[0] = emitir(IRTN(IR_ABS), tr, lj_ir_ksimd(J, LJ_KSIMD_ABS));
@@ -504,7 +504,7 @@ static void LJ_FASTCALL recff_math_abs(jit_State *J, RecordFFData *rd)
 }
 
 /* Record rounding functions math.floor and math.ceil. */
-static void LJ_FASTCALL recff_math_round(jit_State *J, RecordFFData *rd)
+static void recff_math_round(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (!tref_isinteger(tr)) {  /* Pass through integers unmodified. */
@@ -520,13 +520,13 @@ static void LJ_FASTCALL recff_math_round(jit_State *J, RecordFFData *rd)
 }
 
 /* Record unary math.* functions, mapped to IR_FPMATH opcode. */
-static void LJ_FASTCALL recff_math_unary(jit_State *J, RecordFFData *rd)
+static void recff_math_unary(jit_State *J, RecordFFData *rd)
 {
   J->base[0] = emitir(IRTN(IR_FPMATH), lj_ir_tonum(J, J->base[0]), rd->data);
 }
 
 /* Record math.log. */
-static void LJ_FASTCALL recff_math_log(jit_State *J, RecordFFData *rd)
+static void recff_math_log(jit_State *J, RecordFFData *rd)
 {
   TRef tr = lj_ir_tonum(J, J->base[0]);
   if (J->base[1]) {
@@ -548,7 +548,7 @@ static void LJ_FASTCALL recff_math_log(jit_State *J, RecordFFData *rd)
 }
 
 /* Record math.atan2. */
-static void LJ_FASTCALL recff_math_atan2(jit_State *J, RecordFFData *rd)
+static void recff_math_atan2(jit_State *J, RecordFFData *rd)
 {
   TRef tr = lj_ir_tonum(J, J->base[0]);
   TRef tr2 = lj_ir_tonum(J, J->base[1]);
@@ -557,7 +557,7 @@ static void LJ_FASTCALL recff_math_atan2(jit_State *J, RecordFFData *rd)
 }
 
 /* Record math.ldexp. */
-static void LJ_FASTCALL recff_math_ldexp(jit_State *J, RecordFFData *rd)
+static void recff_math_ldexp(jit_State *J, RecordFFData *rd)
 {
   TRef tr = lj_ir_tonum(J, J->base[0]);
   TRef tr2 = lj_ir_tonum(J, J->base[1]);
@@ -566,7 +566,7 @@ static void LJ_FASTCALL recff_math_ldexp(jit_State *J, RecordFFData *rd)
 }
 
 /* Record math.asin, math.acos, math.atan. */
-static void LJ_FASTCALL recff_math_atrig(jit_State *J, RecordFFData *rd)
+static void recff_math_atrig(jit_State *J, RecordFFData *rd)
 {
   TRef y = lj_ir_tonum(J, J->base[0]);
   TRef x = lj_ir_knum_one(J);
@@ -580,13 +580,13 @@ static void LJ_FASTCALL recff_math_atrig(jit_State *J, RecordFFData *rd)
   J->base[0] = emitir(IRTN(IR_ATAN2), y, x);
 }
 
-static void LJ_FASTCALL recff_math_htrig(jit_State *J, RecordFFData *rd)
+static void recff_math_htrig(jit_State *J, RecordFFData *rd)
 {
   TRef tr = lj_ir_tonum(J, J->base[0]);
   J->base[0] = emitir(IRTN(IR_CALLN), tr, rd->data);
 }
 
-static void LJ_FASTCALL recff_math_modf(jit_State *J, RecordFFData *rd)
+static void recff_math_modf(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tref_isinteger(tr)) {
@@ -602,14 +602,14 @@ static void LJ_FASTCALL recff_math_modf(jit_State *J, RecordFFData *rd)
   rd->nres = 2;
 }
 
-static void LJ_FASTCALL recff_math_pow(jit_State *J, RecordFFData *rd)
+static void recff_math_pow(jit_State *J, RecordFFData *rd)
 {
   J->base[0] = lj_opt_narrow_pow(J, J->base[0], J->base[1],
 				 &rd->argv[0], &rd->argv[1]);
   UNUSED(rd);
 }
 
-static void LJ_FASTCALL recff_math_minmax(jit_State *J, RecordFFData *rd)
+static void recff_math_minmax(jit_State *J, RecordFFData *rd)
 {
   TRef tr = lj_ir_tonumber(J, J->base[0]);
   uint32_t op = rd->data;
@@ -627,7 +627,7 @@ static void LJ_FASTCALL recff_math_minmax(jit_State *J, RecordFFData *rd)
   J->base[0] = tr;
 }
 
-static void LJ_FASTCALL recff_math_random(jit_State *J, RecordFFData *rd)
+static void recff_math_random(jit_State *J, RecordFFData *rd)
 {
   GCudata *ud = udataV(&J->fn->c.upvalue[0]);
   TRef tr, one;
@@ -657,7 +657,7 @@ static void LJ_FASTCALL recff_math_random(jit_State *J, RecordFFData *rd)
 /* -- Bit library fast functions ------------------------------------------ */
 
 /* Record bit.tobit. */
-static void LJ_FASTCALL recff_bit_tobit(jit_State *J, RecordFFData *rd)
+static void recff_bit_tobit(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tref_iscdata(tr)) { recff_bit64_tobit(J, rd); return; }
@@ -666,7 +666,7 @@ static void LJ_FASTCALL recff_bit_tobit(jit_State *J, RecordFFData *rd)
 }
 
 /* Record unary bit.bnot, bit.bswap. */
-static void LJ_FASTCALL recff_bit_unary(jit_State *J, RecordFFData *rd)
+static void recff_bit_unary(jit_State *J, RecordFFData *rd)
 {
   if (recff_bit64_unary(J, rd))
     return;
@@ -674,7 +674,7 @@ static void LJ_FASTCALL recff_bit_unary(jit_State *J, RecordFFData *rd)
 }
 
 /* Record N-ary bit.band, bit.bor, bit.bxor. */
-static void LJ_FASTCALL recff_bit_nary(jit_State *J, RecordFFData *rd)
+static void recff_bit_nary(jit_State *J, RecordFFData *rd)
 {
   if (recff_bit64_nary(J, rd))
     return;
@@ -689,7 +689,7 @@ static void LJ_FASTCALL recff_bit_nary(jit_State *J, RecordFFData *rd)
 }
 
 /* Record bit shifts. */
-static void LJ_FASTCALL recff_bit_shift(jit_State *J, RecordFFData *rd)
+static void recff_bit_shift(jit_State *J, RecordFFData *rd)
 {
   if (recff_bit64_shift(J, rd))
     return;
@@ -710,7 +710,7 @@ static void LJ_FASTCALL recff_bit_shift(jit_State *J, RecordFFData *rd)
   }
 }
 
-static void LJ_FASTCALL recff_bit_tohex(jit_State *J, RecordFFData *rd)
+static void recff_bit_tohex(jit_State *J, RecordFFData *rd)
 {
   TRef hdr = recff_bufhdr(J);
   TRef tr = recff_bit64_tohex(J, rd, hdr);
@@ -746,7 +746,7 @@ static TRef recff_string_start(jit_State *J, GCstr *s, int32_t *st, TRef tr,
 }
 
 /* Handle string.byte (rd->data = 0) and string.sub (rd->data = 1). */
-static void LJ_FASTCALL recff_string_range(jit_State *J, RecordFFData *rd)
+static void recff_string_range(jit_State *J, RecordFFData *rd)
 {
   TRef trstr = lj_ir_tostr(J, J->base[0]);
   TRef trlen = emitir(IRTI(IR_FLOAD), trstr, IRFL_STR_LEN);
@@ -825,7 +825,7 @@ static void LJ_FASTCALL recff_string_range(jit_State *J, RecordFFData *rd)
   }
 }
 
-static void LJ_FASTCALL recff_string_char(jit_State *J, RecordFFData *rd)
+static void recff_string_char(jit_State *J, RecordFFData *rd)
 {
   TRef k255 = lj_ir_kint(J, 255);
   BCReg i;
@@ -843,7 +843,7 @@ static void LJ_FASTCALL recff_string_char(jit_State *J, RecordFFData *rd)
   UNUSED(rd);
 }
 
-static void LJ_FASTCALL recff_string_rep(jit_State *J, RecordFFData *rd)
+static void recff_string_rep(jit_State *J, RecordFFData *rd)
 {
   TRef str = lj_ir_tostr(J, J->base[0]);
   TRef rep = lj_opt_narrow_toint(J, J->base[1]);
@@ -869,7 +869,7 @@ static void LJ_FASTCALL recff_string_rep(jit_State *J, RecordFFData *rd)
   J->base[0] = emitir(IRT(IR_BUFSTR, IRT_STR), tr, hdr);
 }
 
-static void LJ_FASTCALL recff_string_op(jit_State *J, RecordFFData *rd)
+static void recff_string_op(jit_State *J, RecordFFData *rd)
 {
   TRef str = lj_ir_tostr(J, J->base[0]);
   TRef hdr = recff_bufhdr(J);
@@ -877,7 +877,7 @@ static void LJ_FASTCALL recff_string_op(jit_State *J, RecordFFData *rd)
   J->base[0] = emitir(IRT(IR_BUFSTR, IRT_STR), tr, hdr);
 }
 
-static void LJ_FASTCALL recff_string_find(jit_State *J, RecordFFData *rd)
+static void recff_string_find(jit_State *J, RecordFFData *rd)
 {
   TRef trstr = lj_ir_tostr(J, J->base[0]);
   TRef trpat = lj_ir_tostr(J, J->base[1]);
@@ -936,7 +936,7 @@ static void LJ_FASTCALL recff_string_find(jit_State *J, RecordFFData *rd)
   }
 }
 
-static void LJ_FASTCALL recff_string_format(jit_State *J, RecordFFData *rd)
+static void recff_string_format(jit_State *J, RecordFFData *rd)
 {
   TRef trfmt = lj_ir_tostr(J, J->base[0]);
   GCstr *fmt = argv2str(J, &rd->argv[0]);
@@ -1014,7 +1014,7 @@ static void LJ_FASTCALL recff_string_format(jit_State *J, RecordFFData *rd)
 
 /* -- Table library fast functions ---------------------------------------- */
 
-static void LJ_FASTCALL recff_table_insert(jit_State *J, RecordFFData *rd)
+static void recff_table_insert(jit_State *J, RecordFFData *rd)
 {
   RecordIndex ix;
   ix.tab = J->base[0];
@@ -1036,7 +1036,7 @@ static void LJ_FASTCALL recff_table_insert(jit_State *J, RecordFFData *rd)
   }  /* else: Interpreter will throw. */
 }
 
-static void LJ_FASTCALL recff_table_concat(jit_State *J, RecordFFData *rd)
+static void recff_table_concat(jit_State *J, RecordFFData *rd)
 {
   TRef tab = J->base[0];
   if (tref_istab(tab)) {
@@ -1055,7 +1055,7 @@ static void LJ_FASTCALL recff_table_concat(jit_State *J, RecordFFData *rd)
   UNUSED(rd);
 }
 
-static void LJ_FASTCALL recff_table_new(jit_State *J, RecordFFData *rd)
+static void recff_table_new(jit_State *J, RecordFFData *rd)
 {
   TRef tra = lj_opt_narrow_toint(J, J->base[0]);
   TRef trh = lj_opt_narrow_toint(J, J->base[1]);
@@ -1063,7 +1063,7 @@ static void LJ_FASTCALL recff_table_new(jit_State *J, RecordFFData *rd)
   UNUSED(rd);
 }
 
-static void LJ_FASTCALL recff_table_clear(jit_State *J, RecordFFData *rd)
+static void recff_table_clear(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
   if (tref_istab(tr)) {
@@ -1097,7 +1097,7 @@ static TRef recff_io_fp(jit_State *J, TRef *udp, int32_t id)
   return fp;
 }
 
-static void LJ_FASTCALL recff_io_write(jit_State *J, RecordFFData *rd)
+static void recff_io_write(jit_State *J, RecordFFData *rd)
 {
   TRef ud, fp = recff_io_fp(J, &ud, rd->data);
   TRef zero = lj_ir_kint(J, 0);
@@ -1124,7 +1124,7 @@ static void LJ_FASTCALL recff_io_write(jit_State *J, RecordFFData *rd)
   J->base[0] = LJ_52 ? ud : TREF_TRUE;
 }
 
-static void LJ_FASTCALL recff_io_flush(jit_State *J, RecordFFData *rd)
+static void recff_io_flush(jit_State *J, RecordFFData *rd)
 {
   TRef ud, fp = recff_io_fp(J, &ud, rd->data);
   TRef tr = lj_ir_call(J, IRCALL_fflush, fp);
@@ -1135,7 +1135,7 @@ static void LJ_FASTCALL recff_io_flush(jit_State *J, RecordFFData *rd)
 
 /* -- Debug library fast functions ---------------------------------------- */
 
-static void LJ_FASTCALL recff_debug_getmetatable(jit_State *J, RecordFFData *rd)
+static void recff_debug_getmetatable(jit_State *J, RecordFFData *rd)
 {
   GCtab *mt;
   TRef mtref;

--- a/src/lj_func.c
+++ b/src/lj_func.c
@@ -17,7 +17,7 @@
 
 /* -- Prototypes ---------------------------------------------------------- */
 
-void LJ_FASTCALL lj_func_freeproto(global_State *g, GCproto *pt)
+void lj_func_freeproto(global_State *g, GCproto *pt)
 {
   lj_mem_free(g, pt, pt->sizept);
 }
@@ -77,7 +77,7 @@ static GCupval *func_emptyuv(lua_State *L)
 }
 
 /* Close all open upvalues pointing to some stack level or above. */
-void LJ_FASTCALL lj_func_closeuv(lua_State *L, TValue *level)
+void lj_func_closeuv(lua_State *L, TValue *level)
 {
   GCupval *uv;
   global_State *g = G(L);
@@ -95,7 +95,7 @@ void LJ_FASTCALL lj_func_closeuv(lua_State *L, TValue *level)
   }
 }
 
-void LJ_FASTCALL lj_func_freeuv(global_State *g, GCupval *uv)
+void lj_func_freeuv(global_State *g, GCupval *uv)
 {
   if (!uv->closed)
     unlinkuv(uv);
@@ -178,7 +178,7 @@ GCfunc *lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent)
   return fn;
 }
 
-void LJ_FASTCALL lj_func_free(global_State *g, GCfunc *fn)
+void lj_func_free(global_State *g, GCfunc *fn)
 {
   MSize size = isluafunc(fn) ? sizeLfunc((MSize)fn->l.nupvalues) :
 			       sizeCfunc((MSize)fn->c.nupvalues);

--- a/src/lj_func.h
+++ b/src/lj_func.h
@@ -9,16 +9,16 @@
 #include "lj_obj.h"
 
 /* Prototypes. */
-LJ_FUNC void LJ_FASTCALL lj_func_freeproto(global_State *g, GCproto *pt);
+LJ_FUNC void lj_func_freeproto(global_State *g, GCproto *pt);
 
 /* Upvalues. */
-LJ_FUNCA void LJ_FASTCALL lj_func_closeuv(lua_State *L, TValue *level);
-LJ_FUNC void LJ_FASTCALL lj_func_freeuv(global_State *g, GCupval *uv);
+LJ_FUNCA void lj_func_closeuv(lua_State *L, TValue *level);
+LJ_FUNC void lj_func_freeuv(global_State *g, GCupval *uv);
 
 /* Functions (closures). */
 LJ_FUNC GCfunc *lj_func_newC(lua_State *L, MSize nelems, GCtab *env);
 LJ_FUNC GCfunc *lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env);
 LJ_FUNCA GCfunc *lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent);
-LJ_FUNC void LJ_FASTCALL lj_func_free(global_State *g, GCfunc *c);
+LJ_FUNC void lj_func_free(global_State *g, GCfunc *c);
 
 #endif

--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -344,7 +344,7 @@ static size_t gc_propagate_gray(global_State *g)
 /* -- Sweep phase --------------------------------------------------------- */
 
 /* Type of GC free functions. */
-typedef void (LJ_FASTCALL *GCFreeFunc)(global_State *g, GCobj *o);
+typedef void (*GCFreeFunc)(global_State *g, GCobj *o);
 
 /* GC free functions for LJ_TSTR .. LJ_TUDATA. ORDER LJ_T */
 static const GCFreeFunc gc_freefunc[] = {
@@ -643,7 +643,7 @@ static size_t gc_onestep(lua_State *L)
 }
 
 /* Perform a limited amount of incremental GC steps. */
-int LJ_FASTCALL lj_gc_step(lua_State *L)
+int lj_gc_step(lua_State *L)
 {
   global_State *g = G(L);
   GCSize lim;
@@ -675,14 +675,14 @@ int LJ_FASTCALL lj_gc_step(lua_State *L)
 }
 
 /* Ditto, but fix the stack top first. */
-void LJ_FASTCALL lj_gc_step_fixtop(lua_State *L)
+void lj_gc_step_fixtop(lua_State *L)
 {
   if (curr_funcisL(L)) L->top = curr_topL(L);
   lj_gc_step(L);
 }
 
 /* Perform multiple GC steps. Called from JIT-compiled code. */
-int LJ_FASTCALL lj_gc_step_jit(global_State *g, MSize steps)
+int lj_gc_step_jit(global_State *g, MSize steps)
 {
   lua_State *L = gco2th(gcref(g->cur_L));
   L->base = tvref(G(L)->jit_base);
@@ -733,7 +733,7 @@ void lj_gc_barrierf(global_State *g, GCobj *o, GCobj *v)
 }
 
 /* Specialized barrier for closed upvalue. Pass &uv->tv. */
-void LJ_FASTCALL lj_gc_barrieruv(global_State *g, TValue *tv)
+void lj_gc_barrieruv(global_State *g, TValue *tv)
 {
 #define TV2MARKED(x) \
   (*((uint8_t *)(x) - offsetof(GCupval, tv) + offsetof(GCupval, marked)))
@@ -790,7 +790,7 @@ void *lj_mem_realloc(lua_State *L, void *p, GCSize osz, GCSize nsz)
 }
 
 /* Allocate new GC object and link it to the root set. */
-void * LJ_FASTCALL lj_mem_newgco(lua_State *L, GCSize size)
+void * lj_mem_newgco(lua_State *L, GCSize size)
 {
   global_State *g = G(L);
   GCobj *o = (GCobj *)g->allocf(g->allocd, NULL, 0, size);

--- a/src/lj_gc.h
+++ b/src/lj_gc.h
@@ -50,9 +50,9 @@ LJ_FUNC size_t lj_gc_separateudata(global_State *g, int all);
 LJ_FUNC void lj_gc_finalize_udata(lua_State *L);
 LJ_FUNC void lj_gc_finalize_cdata(lua_State *L);
 LJ_FUNC void lj_gc_freeall(global_State *g);
-LJ_FUNCA int LJ_FASTCALL lj_gc_step(lua_State *L);
-LJ_FUNCA void LJ_FASTCALL lj_gc_step_fixtop(lua_State *L);
-LJ_FUNC int LJ_FASTCALL lj_gc_step_jit(global_State *g, MSize steps);
+LJ_FUNCA int lj_gc_step(lua_State *L);
+LJ_FUNCA void lj_gc_step_fixtop(lua_State *L);
+LJ_FUNC int lj_gc_step_jit(global_State *g, MSize steps);
 LJ_FUNC void lj_gc_fullgc(lua_State *L);
 
 /* GC check: drive collector forward if the GC threshold has been reached. */
@@ -65,7 +65,7 @@ LJ_FUNC void lj_gc_fullgc(lua_State *L);
 
 /* Write barriers. */
 LJ_FUNC void lj_gc_barrierf(global_State *g, GCobj *o, GCobj *v);
-LJ_FUNCA void LJ_FASTCALL lj_gc_barrieruv(global_State *g, TValue *tv);
+LJ_FUNCA void lj_gc_barrieruv(global_State *g, TValue *tv);
 LJ_FUNC void lj_gc_closeuv(global_State *g, GCupval *uv);
 LJ_FUNC void lj_gc_barriertrace(global_State *g, uint32_t traceno);
 
@@ -100,7 +100,7 @@ static LJ_AINLINE void lj_gc_barrierback(global_State *g, GCtab *t)
 
 /* Allocator. */
 LJ_FUNC void *lj_mem_realloc(lua_State *L, void *p, GCSize osz, GCSize nsz);
-LJ_FUNC void * LJ_FASTCALL lj_mem_newgco(lua_State *L, GCSize size);
+LJ_FUNC void * lj_mem_newgco(lua_State *L, GCSize size);
 LJ_FUNC void *lj_mem_grow(lua_State *L, void *p,
 			  MSize *szp, MSize lim, MSize esz);
 

--- a/src/lj_ir.c
+++ b/src/lj_ir.c
@@ -66,7 +66,7 @@ IRCALLDEF(IRCALLCI)
 /* -- IR emitter ---------------------------------------------------------- */
 
 /* Grow IR buffer at the top. */
-void LJ_FASTCALL lj_ir_growtop(jit_State *J)
+void lj_ir_growtop(jit_State *J)
 {
   IRIns *baseir = J->irbuf + J->irbotlim;
   MSize szins = J->irtoplim - J->irbotlim;
@@ -109,7 +109,7 @@ static void lj_ir_growbot(jit_State *J)
 }
 
 /* Emit IR without any optimizations. */
-TRef LJ_FASTCALL lj_ir_emit(jit_State *J)
+TRef lj_ir_emit(jit_State *J)
 {
   IRRef ref = lj_ir_nextins(J);
   IRIns *ir = IR(ref);
@@ -187,7 +187,7 @@ static LJ_AINLINE IRRef ir_nextk64(jit_State *J)
 #define ir_nextkgc ir_nextk64
 
 /* Intern int32_t constant. */
-TRef LJ_FASTCALL lj_ir_kint(jit_State *J, int32_t k)
+TRef lj_ir_kint(jit_State *J, int32_t k)
 {
   IRIns *ir, *cir = J->cur.ir;
   IRRef ref;
@@ -388,7 +388,7 @@ void lj_ir_kvalue(lua_State *L, TValue *tv, const IRIns *ir)
 /* -- Convert IR operand types -------------------------------------------- */
 
 /* Convert from string to number. */
-TRef LJ_FASTCALL lj_ir_tonumber(jit_State *J, TRef tr)
+TRef lj_ir_tonumber(jit_State *J, TRef tr)
 {
   if (!tref_isnumber(tr)) {
     if (tref_isstr(tr))
@@ -400,7 +400,7 @@ TRef LJ_FASTCALL lj_ir_tonumber(jit_State *J, TRef tr)
 }
 
 /* Convert from integer or string to number. */
-TRef LJ_FASTCALL lj_ir_tonum(jit_State *J, TRef tr)
+TRef lj_ir_tonum(jit_State *J, TRef tr)
 {
   if (!tref_isnum(tr)) {
     if (tref_isinteger(tr))
@@ -414,7 +414,7 @@ TRef LJ_FASTCALL lj_ir_tonum(jit_State *J, TRef tr)
 }
 
 /* Convert from integer or number to string. */
-TRef LJ_FASTCALL lj_ir_tostr(jit_State *J, TRef tr)
+TRef lj_ir_tostr(jit_State *J, TRef tr)
 {
   if (!tref_isstr(tr)) {
     if (!tref_isnumber(tr))

--- a/src/lj_iropt.h
+++ b/src/lj_iropt.h
@@ -12,8 +12,8 @@
 #include "lj_jit.h"
 
 /* IR emitter. */
-LJ_FUNC void LJ_FASTCALL lj_ir_growtop(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_ir_emit(jit_State *J);
+LJ_FUNC void lj_ir_growtop(jit_State *J);
+LJ_FUNC TRef lj_ir_emit(jit_State *J);
 
 /* Save current IR in J->fold.ins, but do not emit it (yet). */
 static LJ_AINLINE void lj_ir_set_(jit_State *J, uint16_t ot, IRRef1 a, IRRef1 b)
@@ -38,7 +38,7 @@ static LJ_AINLINE IRRef lj_ir_nextins(jit_State *J)
 LJ_FUNC TRef lj_ir_ggfload(jit_State *J, IRType t, uintptr_t ofs);
 
 /* Interning of constants. */
-LJ_FUNC TRef LJ_FASTCALL lj_ir_kint(jit_State *J, int32_t k);
+LJ_FUNC TRef lj_ir_kint(jit_State *J, int32_t k);
 LJ_FUNC TRef lj_ir_k64(jit_State *J, IROp op, uint64_t u64);
 LJ_FUNC TRef lj_ir_knum_u64(jit_State *J, uint64_t u64);
 LJ_FUNC TRef lj_ir_knumint(jit_State *J, lua_Number n);
@@ -77,9 +77,9 @@ static LJ_AINLINE TRef lj_ir_knum(jit_State *J, lua_Number n)
 LJ_FUNC void lj_ir_kvalue(lua_State *L, TValue *tv, const IRIns *ir);
 
 /* Convert IR operand types. */
-LJ_FUNC TRef LJ_FASTCALL lj_ir_tonumber(jit_State *J, TRef tr);
-LJ_FUNC TRef LJ_FASTCALL lj_ir_tonum(jit_State *J, TRef tr);
-LJ_FUNC TRef LJ_FASTCALL lj_ir_tostr(jit_State *J, TRef tr);
+LJ_FUNC TRef lj_ir_tonumber(jit_State *J, TRef tr);
+LJ_FUNC TRef lj_ir_tonum(jit_State *J, TRef tr);
+LJ_FUNC TRef lj_ir_tostr(jit_State *J, TRef tr);
 
 /* Miscellaneous IR ops. */
 LJ_FUNC int lj_ir_numcmp(lua_Number a, lua_Number b, IROp op);
@@ -87,9 +87,9 @@ LJ_FUNC int lj_ir_strcmp(GCstr *a, GCstr *b, IROp op);
 LJ_FUNC void lj_ir_rollback(jit_State *J, IRRef ref);
 
 /* Emit IR instructions with on-the-fly optimizations. */
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fold(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_cse(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_cselim(jit_State *J, IRRef lim);
+LJ_FUNC TRef lj_opt_fold(jit_State *J);
+LJ_FUNC TRef lj_opt_cse(jit_State *J);
+LJ_FUNC TRef lj_opt_cselim(jit_State *J, IRRef lim);
 
 /* Special return values for the fold functions. */
 enum {
@@ -110,29 +110,29 @@ enum {
 #define EMITFOLD	(lj_ir_emit(J))
 
 /* Load/store forwarding. */
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_aload(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_hload(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_uload(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_fload(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_xload(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_tab_len(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_fwd_hrefk(jit_State *J);
-LJ_FUNC int LJ_FASTCALL lj_opt_fwd_href_nokey(jit_State *J);
-LJ_FUNC int LJ_FASTCALL lj_opt_fwd_tptr(jit_State *J, IRRef lim);
+LJ_FUNC TRef lj_opt_fwd_aload(jit_State *J);
+LJ_FUNC TRef lj_opt_fwd_hload(jit_State *J);
+LJ_FUNC TRef lj_opt_fwd_uload(jit_State *J);
+LJ_FUNC TRef lj_opt_fwd_fload(jit_State *J);
+LJ_FUNC TRef lj_opt_fwd_xload(jit_State *J);
+LJ_FUNC TRef lj_opt_fwd_tab_len(jit_State *J);
+LJ_FUNC TRef lj_opt_fwd_hrefk(jit_State *J);
+LJ_FUNC int lj_opt_fwd_href_nokey(jit_State *J);
+LJ_FUNC int lj_opt_fwd_tptr(jit_State *J, IRRef lim);
 LJ_FUNC int lj_opt_fwd_wasnonnil(jit_State *J, IROpT loadop, IRRef xref);
 
 /* Dead-store elimination. */
-LJ_FUNC TRef LJ_FASTCALL lj_opt_dse_ahstore(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_dse_ustore(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_dse_fstore(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_dse_xstore(jit_State *J);
+LJ_FUNC TRef lj_opt_dse_ahstore(jit_State *J);
+LJ_FUNC TRef lj_opt_dse_ustore(jit_State *J);
+LJ_FUNC TRef lj_opt_dse_fstore(jit_State *J);
+LJ_FUNC TRef lj_opt_dse_xstore(jit_State *J);
 
 /* Narrowing. */
-LJ_FUNC TRef LJ_FASTCALL lj_opt_narrow_convert(jit_State *J);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_narrow_index(jit_State *J, TRef key);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_narrow_toint(jit_State *J, TRef tr);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_narrow_tobit(jit_State *J, TRef tr);
-LJ_FUNC TRef LJ_FASTCALL lj_opt_narrow_cindex(jit_State *J, TRef key);
+LJ_FUNC TRef lj_opt_narrow_convert(jit_State *J);
+LJ_FUNC TRef lj_opt_narrow_index(jit_State *J, TRef key);
+LJ_FUNC TRef lj_opt_narrow_toint(jit_State *J, TRef tr);
+LJ_FUNC TRef lj_opt_narrow_tobit(jit_State *J, TRef tr);
+LJ_FUNC TRef lj_opt_narrow_cindex(jit_State *J, TRef key);
 LJ_FUNC TRef lj_opt_narrow_arith(jit_State *J, TRef rb, TRef rc,
 				 TValue *vb, TValue *vc, IROp op);
 LJ_FUNC TRef lj_opt_narrow_unm(jit_State *J, TRef rc, TValue *vc);

--- a/src/lj_lib.h
+++ b/src/lj_lib.h
@@ -95,6 +95,6 @@ LJ_FUNC int lj_lib_postreg(lua_State *L, lua_CFunction cf, int id,
 /* Exported library functions. */
 
 typedef struct RandomState RandomState;
-LJ_FUNC uint64_t LJ_FASTCALL lj_math_random_step(RandomState *rs);
+LJ_FUNC uint64_t lj_math_random_step(RandomState *rs);
 
 #endif

--- a/src/lj_meta.c
+++ b/src/lj_meta.c
@@ -305,7 +305,7 @@ TValue *lj_meta_cat(lua_State *L, TValue *top, int left)
 }
 
 /* Helper for LEN. __len metamethod. */
-TValue * LJ_FASTCALL lj_meta_len(lua_State *L, cTValue *o)
+TValue * lj_meta_len(lua_State *L, cTValue *o)
 {
   cTValue *mo = lj_meta_lookup(L, o, MM_len);
   if (tvisnil(mo)) {
@@ -344,7 +344,7 @@ TValue *lj_meta_equal(lua_State *L, GCobj *o1, GCobj *o2, int ne)
   return (TValue *)(intptr_t)ne;
 }
 
-TValue * LJ_FASTCALL lj_meta_equal_cd(lua_State *L, BCIns ins)
+TValue * lj_meta_equal_cd(lua_State *L, BCIns ins)
 {
   ASMFunction cont = (bc_op(ins) & 1) ? lj_cont_condf : lj_cont_condt;
   int op = (int)bc_op(ins) & ~1;
@@ -442,7 +442,7 @@ void lj_meta_call(lua_State *L, TValue *func, TValue *top)
 }
 
 /* Helper for FORI. Coercion. */
-void LJ_FASTCALL lj_meta_for(lua_State *L, TValue *o)
+void lj_meta_for(lua_State *L, TValue *o)
 {
   if (!lj_strscan_numberobj(o)) lj_err_msg(L, LJ_ERR_FORINIT);
   if (!lj_strscan_numberobj(o+1)) lj_err_msg(L, LJ_ERR_FORLIM);

--- a/src/lj_meta.h
+++ b/src/lj_meta.h
@@ -25,12 +25,12 @@ LJ_FUNCA TValue *lj_meta_tset(lua_State *L, cTValue *o, cTValue *k);
 LJ_FUNCA TValue *lj_meta_arith(lua_State *L, TValue *ra, cTValue *rb,
 			       cTValue *rc, BCReg op);
 LJ_FUNCA TValue *lj_meta_cat(lua_State *L, TValue *top, int left);
-LJ_FUNCA TValue * LJ_FASTCALL lj_meta_len(lua_State *L, cTValue *o);
+LJ_FUNCA TValue * lj_meta_len(lua_State *L, cTValue *o);
 LJ_FUNCA TValue *lj_meta_equal(lua_State *L, GCobj *o1, GCobj *o2, int ne);
-LJ_FUNCA TValue * LJ_FASTCALL lj_meta_equal_cd(lua_State *L, BCIns ins);
+LJ_FUNCA TValue * lj_meta_equal_cd(lua_State *L, BCIns ins);
 LJ_FUNCA TValue *lj_meta_comp(lua_State *L, cTValue *o1, cTValue *o2, int op);
 LJ_FUNCA void lj_meta_istype(lua_State *L, BCReg ra, BCReg tp);
 LJ_FUNCA void lj_meta_call(lua_State *L, TValue *func, TValue *top);
-LJ_FUNCA void LJ_FASTCALL lj_meta_for(lua_State *L, TValue *o);
+LJ_FUNCA void lj_meta_for(lua_State *L, TValue *o);
 
 #endif

--- a/src/lj_obj.c
+++ b/src/lj_obj.c
@@ -20,7 +20,7 @@ LJ_DATADEF const char *const lj_obj_itypename[] = {  /* ORDER LJ_T */
 };
 
 /* Compare two objects without calling metamethods. */
-int LJ_FASTCALL lj_obj_equal(cTValue *o1, cTValue *o2)
+int lj_obj_equal(cTValue *o1, cTValue *o2)
 {
   if (itype(o1) == itype(o2)) {
     if (tvispri(o1))
@@ -34,7 +34,7 @@ int LJ_FASTCALL lj_obj_equal(cTValue *o1, cTValue *o2)
 }
 
 /* Return pointer to object or its object data. */
-const void * LJ_FASTCALL lj_obj_ptr(cTValue *o)
+const void * lj_obj_ptr(cTValue *o)
 {
   if (tvisudata(o))
     return uddata(udataV(o));

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -815,7 +815,7 @@ LJ_DATA const char *const lj_obj_itypename[~LJ_TNUMX+1];
 #define lj_typename(o)	(lj_obj_itypename[itypemap(o)])
 
 /* Compare two objects without calling metamethods. */
-LJ_FUNC int LJ_FASTCALL lj_obj_equal(cTValue *o1, cTValue *o2);
-LJ_FUNC const void * LJ_FASTCALL lj_obj_ptr(cTValue *o);
+LJ_FUNC int lj_obj_equal(cTValue *o1, cTValue *o2);
+LJ_FUNC const void * lj_obj_ptr(cTValue *o);
 
 #endif

--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -142,12 +142,12 @@
 #define emitir(ot, a, b)	(lj_ir_set(J, (ot), (a), (b)), lj_opt_fold(J))
 
 /* Fold function type. Fastcall on x86 significantly reduces their size. */
-typedef IRRef (LJ_FASTCALL *FoldFunc)(jit_State *J);
+typedef IRRef (*FoldFunc)(jit_State *J);
 
 /* Macros for the fold specs, so buildvm can recognize them. */
 #define LJFOLD(x)
 #define LJFOLDX(x)
-#define LJFOLDF(name)	static TRef LJ_FASTCALL fold_##name(jit_State *J)
+#define LJFOLDF(name)	static TRef fold_##name(jit_State *J)
 /* Note: They must be at the start of a line or buildvm ignores them! */
 
 /* Barrier to prevent using operands across PHIs. */
@@ -604,7 +604,7 @@ LJFOLDF(bufput_kfold_op)
   if (irref_isk(fleft->op2)) {
     const CCallInfo *ci = &lj_ir_callinfo[fins->op2];
     SBuf *sb = lj_buf_tmp_(J->L);
-    sb = ((SBuf * (LJ_FASTCALL *)(SBuf *, GCstr *))ci->func)(sb,
+    sb = ((SBuf * (*)(SBuf *, GCstr *))ci->func)(sb,
 						       ir_kstr(IR(fleft->op2)));
     fins->o = IR_BUFPUT;
     fins->op1 = fleft->op1;
@@ -2310,7 +2310,7 @@ LJFOLDX(lj_ir_emit)
 /* ------------------------------------------------------------------------ */
 
 /* Fold IR instruction. */
-TRef LJ_FASTCALL lj_opt_fold(jit_State *J)
+TRef lj_opt_fold(jit_State *J)
 {
   uint32_t key, any;
   IRRef ref;
@@ -2386,7 +2386,7 @@ retry:
 /* -- Common-Subexpression Elimination ------------------------------------ */
 
 /* CSE an IR instruction. This is very fast due to the skip-list chains. */
-TRef LJ_FASTCALL lj_opt_cse(jit_State *J)
+TRef lj_opt_cse(jit_State *J)
 {
   /* Avoid narrow to wide store-to-load forwarding stall */
   IRRef2 op12 = (IRRef2)fins->op1 + ((IRRef2)fins->op2 << 16);
@@ -2416,7 +2416,7 @@ TRef LJ_FASTCALL lj_opt_cse(jit_State *J)
 }
 
 /* CSE with explicit search limit. */
-TRef LJ_FASTCALL lj_opt_cselim(jit_State *J, IRRef lim)
+TRef lj_opt_cselim(jit_State *J, IRRef lim)
 {
   IRRef ref = J->chain[fins->o];
   IRRef2 op12 = (IRRef2)fins->op1 + ((IRRef2)fins->op2 << 16);

--- a/src/lj_opt_mem.c
+++ b/src/lj_opt_mem.c
@@ -238,7 +238,7 @@ static TRef fwd_aload_reassoc(jit_State *J)
 }
 
 /* ALOAD forwarding. */
-TRef LJ_FASTCALL lj_opt_fwd_aload(jit_State *J)
+TRef lj_opt_fwd_aload(jit_State *J)
 {
   IRRef ref;
   if ((ref = fwd_ahload(J, fins->op1)) ||
@@ -248,7 +248,7 @@ TRef LJ_FASTCALL lj_opt_fwd_aload(jit_State *J)
 }
 
 /* HLOAD forwarding. */
-TRef LJ_FASTCALL lj_opt_fwd_hload(jit_State *J)
+TRef lj_opt_fwd_hload(jit_State *J)
 {
   IRRef ref = fwd_ahload(J, fins->op1);
   if (ref)
@@ -257,7 +257,7 @@ TRef LJ_FASTCALL lj_opt_fwd_hload(jit_State *J)
 }
 
 /* HREFK forwarding. */
-TRef LJ_FASTCALL lj_opt_fwd_hrefk(jit_State *J)
+TRef lj_opt_fwd_hrefk(jit_State *J)
 {
   IRRef tab = fleft->op1;
   IRRef ref = J->chain[IR_NEWREF];
@@ -281,7 +281,7 @@ docse:
 }
 
 /* Check whether HREF of TNEW/TDUP can be folded to niltv. */
-int LJ_FASTCALL lj_opt_fwd_href_nokey(jit_State *J)
+int lj_opt_fwd_href_nokey(jit_State *J)
 {
   IRRef lim = fins->op1;  /* Search limit. */
   IRRef ref;
@@ -323,7 +323,7 @@ static int fwd_aa_tab_clear(jit_State *J, IRRef lim, IRRef ta)
 }
 
 /* Check whether there's no aliasing NEWREF/table.clear for the left operand. */
-int LJ_FASTCALL lj_opt_fwd_tptr(jit_State *J, IRRef lim)
+int lj_opt_fwd_tptr(jit_State *J, IRRef lim)
 {
   IRRef ta = fins->op1;
   IRRef ref = J->chain[IR_NEWREF];
@@ -337,7 +337,7 @@ int LJ_FASTCALL lj_opt_fwd_tptr(jit_State *J, IRRef lim)
 }
 
 /* ASTORE/HSTORE elimination. */
-TRef LJ_FASTCALL lj_opt_dse_ahstore(jit_State *J)
+TRef lj_opt_dse_ahstore(jit_State *J)
 {
   IRRef xref = fins->op1;  /* xREF reference. */
   IRRef val = fins->op2;  /* Stored value reference. */
@@ -407,7 +407,7 @@ static AliasRet aa_uref(IRIns *refa, IRIns *refb)
 }
 
 /* ULOAD forwarding. */
-TRef LJ_FASTCALL lj_opt_fwd_uload(jit_State *J)
+TRef lj_opt_fwd_uload(jit_State *J)
 {
   IRRef uref = fins->op1;
   IRRef lim = REF_BASE;  /* Search limit. */
@@ -441,7 +441,7 @@ cselim:
 }
 
 /* USTORE elimination. */
-TRef LJ_FASTCALL lj_opt_dse_ustore(jit_State *J)
+TRef lj_opt_dse_ustore(jit_State *J)
 {
   IRRef xref = fins->op1;  /* xREF reference. */
   IRRef val = fins->op2;  /* Stored value reference. */
@@ -515,7 +515,7 @@ static AliasRet aa_fref(jit_State *J, IRIns *refa, IRIns *refb)
 }
 
 /* Only the loads for mutable fields end up here (see FOLD). */
-TRef LJ_FASTCALL lj_opt_fwd_fload(jit_State *J)
+TRef lj_opt_fwd_fload(jit_State *J)
 {
   IRRef oref = fins->op1;  /* Object reference. */
   IRRef fid = fins->op2;  /* Field ID. */
@@ -547,7 +547,7 @@ cselim:
 }
 
 /* FSTORE elimination. */
-TRef LJ_FASTCALL lj_opt_dse_fstore(jit_State *J)
+TRef lj_opt_dse_fstore(jit_State *J)
 {
   IRRef fref = fins->op1;  /* FREF reference. */
   IRRef val = fins->op2;  /* Stored value reference. */
@@ -729,7 +729,7 @@ static IRRef reassoc_xref(jit_State *J, IRIns *ir)
 }
 
 /* XLOAD forwarding. */
-TRef LJ_FASTCALL lj_opt_fwd_xload(jit_State *J)
+TRef lj_opt_fwd_xload(jit_State *J)
 {
   IRRef xref = fins->op1;
   IRIns *xr = IR(xref);
@@ -797,7 +797,7 @@ doemit:
 }
 
 /* XSTORE elimination. */
-TRef LJ_FASTCALL lj_opt_dse_xstore(jit_State *J)
+TRef lj_opt_dse_xstore(jit_State *J)
 {
   IRRef xref = fins->op1;
   IRIns *xr = IR(xref);
@@ -846,7 +846,7 @@ doemit:
 /* -- Forwarding of lj_tab_len -------------------------------------------- */
 
 /* This is rather simplistic right now, but better than nothing. */
-TRef LJ_FASTCALL lj_opt_fwd_tab_len(jit_State *J)
+TRef lj_opt_fwd_tab_len(jit_State *J)
 {
   IRRef tab = fins->op1;  /* Table reference. */
   IRRef lim = tab;  /* Search limit. */

--- a/src/lj_opt_narrow.c
+++ b/src/lj_opt_narrow.c
@@ -402,7 +402,7 @@ static IRRef narrow_conv_emit(jit_State *J, NarrowConv *nc)
 }
 
 /* Narrow a type conversion of an arithmetic operation. */
-TRef LJ_FASTCALL lj_opt_narrow_convert(jit_State *J)
+TRef lj_opt_narrow_convert(jit_State *J)
 {
   if ((J->flags & JIT_F_OPT_NARROW)) {
     NarrowConv nc;
@@ -448,7 +448,7 @@ static TRef narrow_stripov(jit_State *J, TRef tr, int lastop, IRRef mode)
 }
 
 /* Narrow array index. */
-TRef LJ_FASTCALL lj_opt_narrow_index(jit_State *J, TRef tr)
+TRef lj_opt_narrow_index(jit_State *J, TRef tr)
 {
   IRIns *ir;
   lua_assert(tref_isnumber(tr));
@@ -463,7 +463,7 @@ TRef LJ_FASTCALL lj_opt_narrow_index(jit_State *J, TRef tr)
 }
 
 /* Narrow conversion to integer operand (overflow undefined). */
-TRef LJ_FASTCALL lj_opt_narrow_toint(jit_State *J, TRef tr)
+TRef lj_opt_narrow_toint(jit_State *J, TRef tr)
 {
   if (tref_isstr(tr))
     tr = emitir(IRTG(IR_STRTO, IRT_NUM), tr, 0);
@@ -479,7 +479,7 @@ TRef LJ_FASTCALL lj_opt_narrow_toint(jit_State *J, TRef tr)
 }
 
 /* Narrow conversion to bitop operand (overflow wrapped). */
-TRef LJ_FASTCALL lj_opt_narrow_tobit(jit_State *J, TRef tr)
+TRef lj_opt_narrow_tobit(jit_State *J, TRef tr)
 {
   if (tref_isstr(tr))
     tr = emitir(IRTG(IR_STRTO, IRT_NUM), tr, 0);
@@ -495,7 +495,7 @@ TRef LJ_FASTCALL lj_opt_narrow_tobit(jit_State *J, TRef tr)
 }
 
 /* Narrow C array index (overflow undefined). */
-TRef LJ_FASTCALL lj_opt_narrow_cindex(jit_State *J, TRef tr)
+TRef lj_opt_narrow_cindex(jit_State *J, TRef tr)
 {
   lua_assert(tref_isnumber(tr));
   if (tref_isnum(tr))

--- a/src/lj_state.c
+++ b/src/lj_state.c
@@ -96,7 +96,7 @@ void lj_state_shrinkstack(lua_State *L, MSize used)
 }
 
 /* Try to grow stack. */
-void LJ_FASTCALL lj_state_growstack(lua_State *L, MSize need)
+void lj_state_growstack(lua_State *L, MSize need)
 {
   MSize n;
   if (L->stacksize > LJ_STACK_MAXEX)  /* Overflow while handling overflow? */
@@ -114,7 +114,7 @@ void LJ_FASTCALL lj_state_growstack(lua_State *L, MSize need)
     lj_err_msg(L, LJ_ERR_STKOV);
 }
 
-void LJ_FASTCALL lj_state_growstack1(lua_State *L)
+void lj_state_growstack1(lua_State *L)
 {
   lj_state_growstack(L, 1);
 }
@@ -271,7 +271,7 @@ lua_State *lj_state_new(lua_State *L)
   return L1;
 }
 
-void LJ_FASTCALL lj_state_free(global_State *g, lua_State *L)
+void lj_state_free(global_State *g, lua_State *L)
 {
   lua_assert(L != mainthread(g));
   if (obj2gco(L) == gcref(g->cur_L))

--- a/src/lj_state.h
+++ b/src/lj_state.h
@@ -16,8 +16,8 @@
 
 LJ_FUNC void lj_state_relimitstack(lua_State *L);
 LJ_FUNC void lj_state_shrinkstack(lua_State *L, MSize used);
-LJ_FUNCA void LJ_FASTCALL lj_state_growstack(lua_State *L, MSize need);
-LJ_FUNC void LJ_FASTCALL lj_state_growstack1(lua_State *L);
+LJ_FUNCA void lj_state_growstack(lua_State *L, MSize need);
+LJ_FUNC void lj_state_growstack1(lua_State *L);
 
 static LJ_AINLINE void lj_state_checkstack(lua_State *L, MSize need)
 {
@@ -27,6 +27,6 @@ static LJ_AINLINE void lj_state_checkstack(lua_State *L, MSize need)
 }
 
 LJ_FUNC lua_State *lj_state_new(lua_State *L);
-LJ_FUNC void LJ_FASTCALL lj_state_free(global_State *g, lua_State *L);
+LJ_FUNC void lj_state_free(global_State *g, lua_State *L);
 
 #endif

--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -15,7 +15,7 @@
 /* -- String helpers ------------------------------------------------------ */
 
 /* Ordered compare of strings. Assumes string data is 4-byte aligned. */
-int32_t LJ_FASTCALL lj_str_cmp(GCstr *a, GCstr *b)
+int32_t lj_str_cmp(GCstr *a, GCstr *b)
 {
   MSize i, n = a->len > b->len ? b->len : a->len;
   for (i = 0; i < n; i += 4) {
@@ -189,7 +189,7 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
   return s;  /* Return newly interned string. */
 }
 
-void LJ_FASTCALL lj_str_free(global_State *g, GCstr *s)
+void lj_str_free(global_State *g, GCstr *s)
 {
   g->strnum--;
   lj_mem_free(g, s, sizestring(s));

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -11,7 +11,7 @@
 #include "lj_obj.h"
 
 /* String helpers. */
-LJ_FUNC int32_t LJ_FASTCALL lj_str_cmp(GCstr *a, GCstr *b);
+LJ_FUNC int32_t lj_str_cmp(GCstr *a, GCstr *b);
 LJ_FUNC const char *lj_str_find(const char *s, const char *f,
 				MSize slen, MSize flen);
 LJ_FUNC int lj_str_haspattern(GCstr *s);
@@ -19,7 +19,7 @@ LJ_FUNC int lj_str_haspattern(GCstr *s);
 /* String interning. */
 LJ_FUNC void lj_str_resize(lua_State *L, MSize newmask);
 LJ_FUNCA GCstr *lj_str_new(lua_State *L, const char *str, size_t len);
-LJ_FUNC void LJ_FASTCALL lj_str_free(global_State *g, GCstr *s);
+LJ_FUNC void lj_str_free(global_State *g, GCstr *s);
 
 #define lj_str_newz(L, s)	(lj_str_new(L, s, strlen(s)))
 #define lj_str_newlit(L, s)	(lj_str_new(L, "" s, sizeof(s)-1))

--- a/src/lj_strfmt.c
+++ b/src/lj_strfmt.c
@@ -25,7 +25,7 @@ static const uint8_t strfmt_map[('x'-'A')+1] = {
   0,STRFMT_O,STRFMT_P,STRFMT_Q,0,STRFMT_S,0,STRFMT_U,0,0,STRFMT_X
 };
 
-SFormat LJ_FASTCALL lj_strfmt_parse(FormatState *fs)
+SFormat lj_strfmt_parse(FormatState *fs)
 {
   const uint8_t *p = fs->p, *e = fs->e;
   fs->str = (const char *)p;
@@ -93,7 +93,7 @@ retlit:
   { uint32_t d = (x*(((1<<sh)+sc-1)/sc))>>sh; x -= d*sc; *p++ = (char)('0'+d); }
 
 /* Write integer to buffer. */
-char * LJ_FASTCALL lj_strfmt_wint(char *p, int32_t k)
+char * lj_strfmt_wint(char *p, int32_t k)
 {
   uint32_t u = (uint32_t)k;
   if (k < 0) { u = (uint32_t)-k; *p++ = '-'; }
@@ -126,7 +126,7 @@ char * LJ_FASTCALL lj_strfmt_wint(char *p, int32_t k)
 #undef WINT_R
 
 /* Write pointer to buffer. */
-char * LJ_FASTCALL lj_strfmt_wptr(char *p, const void *v)
+char * lj_strfmt_wptr(char *p, const void *v)
 {
   ptrdiff_t x = (ptrdiff_t)v;
   MSize i, n = STRFMT_MAXBUF_PTR;
@@ -144,7 +144,7 @@ char * LJ_FASTCALL lj_strfmt_wptr(char *p, const void *v)
 }
 
 /* Write ULEB128 to buffer. */
-char * LJ_FASTCALL lj_strfmt_wuleb128(char *p, uint32_t v)
+char * lj_strfmt_wuleb128(char *p, uint32_t v)
 {
   for (; v >= 0x80; v >>= 7)
     *p++ = (char)((v & 0x7f) | 0x80);
@@ -173,26 +173,26 @@ const char *lj_strfmt_wstrnum(lua_State *L, cTValue *o, MSize *lenp)
 /* -- Unformatted conversions to buffer ----------------------------------- */
 
 /* Add integer to buffer. */
-SBuf * LJ_FASTCALL lj_strfmt_putint(SBuf *sb, int32_t k)
+SBuf * lj_strfmt_putint(SBuf *sb, int32_t k)
 {
   setsbufP(sb, lj_strfmt_wint(lj_buf_more(sb, STRFMT_MAXBUF_INT), k));
   return sb;
 }
 
 /* Add number to buffer. */
-SBuf * LJ_FASTCALL lj_strfmt_putnum(SBuf *sb, cTValue *o)
+SBuf * lj_strfmt_putnum(SBuf *sb, cTValue *o)
 {
   return lj_strfmt_putfnum(sb, STRFMT_G14, o->n);
 }
 
-SBuf * LJ_FASTCALL lj_strfmt_putptr(SBuf *sb, const void *v)
+SBuf * lj_strfmt_putptr(SBuf *sb, const void *v)
 {
   setsbufP(sb, lj_strfmt_wptr(lj_buf_more(sb, STRFMT_MAXBUF_PTR), v));
   return sb;
 }
 
 /* Add quoted string to buffer. */
-SBuf * LJ_FASTCALL lj_strfmt_putquoted(SBuf *sb, GCstr *str)
+SBuf * lj_strfmt_putquoted(SBuf *sb, GCstr *str)
 {
   const char *s = strdata(str);
   MSize len = str->len;
@@ -345,7 +345,7 @@ SBuf *lj_strfmt_putfnum_uint(SBuf *sb, SFormat sf, lua_Number n)
 /* -- Conversions to strings ---------------------------------------------- */
 
 /* Convert integer to string. */
-GCstr * LJ_FASTCALL lj_strfmt_int(lua_State *L, int32_t k)
+GCstr * lj_strfmt_int(lua_State *L, int32_t k)
 {
   char buf[STRFMT_MAXBUF_INT];
   MSize len = (MSize)(lj_strfmt_wint(buf, k) - buf);
@@ -353,13 +353,13 @@ GCstr * LJ_FASTCALL lj_strfmt_int(lua_State *L, int32_t k)
 }
 
 /* Convert integer or number to string. */
-GCstr * LJ_FASTCALL lj_strfmt_number(lua_State *L, cTValue *o)
+GCstr * lj_strfmt_number(lua_State *L, cTValue *o)
 {
   return tvisint(o) ? lj_strfmt_int(L, intV(o)) : lj_strfmt_num(L, o);
 }
 
 /* Convert char value to string. */
-GCstr * LJ_FASTCALL lj_strfmt_char(lua_State *L, int c)
+GCstr * lj_strfmt_char(lua_State *L, int c)
 {
   char buf[1];
   buf[0] = c;
@@ -367,7 +367,7 @@ GCstr * LJ_FASTCALL lj_strfmt_char(lua_State *L, int c)
 }
 
 /* Raw conversion of object to string. */
-GCstr * LJ_FASTCALL lj_strfmt_obj(lua_State *L, cTValue *o)
+GCstr * lj_strfmt_obj(lua_State *L, cTValue *o)
 {
   if (tvisstr(o)) {
     return strV(o);

--- a/src/lj_strfmt.h
+++ b/src/lj_strfmt.h
@@ -73,7 +73,7 @@ typedef enum FormatType {
 #define STRFMT_MAXBUF_PTR	(2+2*sizeof(ptrdiff_t))  /* "0x" + hex ptr. */
 
 /* Format parser. */
-LJ_FUNC SFormat LJ_FASTCALL lj_strfmt_parse(FormatState *fs);
+LJ_FUNC SFormat lj_strfmt_parse(FormatState *fs);
 
 static LJ_AINLINE void lj_strfmt_init(FormatState *fs, const char *p, MSize len)
 {
@@ -83,16 +83,16 @@ static LJ_AINLINE void lj_strfmt_init(FormatState *fs, const char *p, MSize len)
 }
 
 /* Raw conversions. */
-LJ_FUNC char * LJ_FASTCALL lj_strfmt_wint(char *p, int32_t k);
-LJ_FUNC char * LJ_FASTCALL lj_strfmt_wptr(char *p, const void *v);
-LJ_FUNC char * LJ_FASTCALL lj_strfmt_wuleb128(char *p, uint32_t v);
+LJ_FUNC char * lj_strfmt_wint(char *p, int32_t k);
+LJ_FUNC char * lj_strfmt_wptr(char *p, const void *v);
+LJ_FUNC char * lj_strfmt_wuleb128(char *p, uint32_t v);
 LJ_FUNC const char *lj_strfmt_wstrnum(lua_State *L, cTValue *o, MSize *lenp);
 
 /* Unformatted conversions to buffer. */
-LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putint(SBuf *sb, int32_t k);
-LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putnum(SBuf *sb, cTValue *o);
-LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putptr(SBuf *sb, const void *v);
-LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putquoted(SBuf *sb, GCstr *str);
+LJ_FUNC SBuf * lj_strfmt_putint(SBuf *sb, int32_t k);
+LJ_FUNC SBuf * lj_strfmt_putnum(SBuf *sb, cTValue *o);
+LJ_FUNC SBuf * lj_strfmt_putptr(SBuf *sb, const void *v);
+LJ_FUNC SBuf * lj_strfmt_putquoted(SBuf *sb, GCstr *str);
 
 /* Formatted conversions to buffer. */
 LJ_FUNC SBuf *lj_strfmt_putfxint(SBuf *sb, SFormat sf, uint64_t k);
@@ -103,11 +103,11 @@ LJ_FUNC SBuf *lj_strfmt_putfchar(SBuf *sb, SFormat, int32_t c);
 LJ_FUNC SBuf *lj_strfmt_putfstr(SBuf *sb, SFormat, GCstr *str);
 
 /* Conversions to strings. */
-LJ_FUNC GCstr * LJ_FASTCALL lj_strfmt_int(lua_State *L, int32_t k);
-LJ_FUNCA GCstr * LJ_FASTCALL lj_strfmt_num(lua_State *L, cTValue *o);
-LJ_FUNCA GCstr * LJ_FASTCALL lj_strfmt_number(lua_State *L, cTValue *o);
-LJ_FUNC GCstr * LJ_FASTCALL lj_strfmt_char(lua_State *L, int c);
-LJ_FUNC GCstr * LJ_FASTCALL lj_strfmt_obj(lua_State *L, cTValue *o);
+LJ_FUNC GCstr * lj_strfmt_int(lua_State *L, int32_t k);
+LJ_FUNCA GCstr * lj_strfmt_num(lua_State *L, cTValue *o);
+LJ_FUNCA GCstr * lj_strfmt_number(lua_State *L, cTValue *o);
+LJ_FUNC GCstr * lj_strfmt_char(lua_State *L, int c);
+LJ_FUNC GCstr * lj_strfmt_obj(lua_State *L, cTValue *o);
 
 /* Internal string formatting. */
 LJ_FUNC const char *lj_strfmt_pushvf(lua_State *L, const char *fmt,

--- a/src/lj_strfmt_num.c
+++ b/src/lj_strfmt_num.c
@@ -578,7 +578,7 @@ SBuf *lj_strfmt_putfnum(SBuf *sb, SFormat sf, lua_Number n)
 /* -- Conversions to strings ---------------------------------------------- */
 
 /* Convert number to string. */
-GCstr * LJ_FASTCALL lj_strfmt_num(lua_State *L, cTValue *o)
+GCstr * lj_strfmt_num(lua_State *L, cTValue *o)
 {
   char buf[STRFMT_MAXBUF_NUM];
   MSize len = (MSize)(lj_strfmt_wfnum(NULL, STRFMT_G14, o->n, buf) - buf);

--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -522,7 +522,7 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt)
   }
 }
 
-int LJ_FASTCALL lj_strscan_num(GCstr *str, TValue *o)
+int lj_strscan_num(GCstr *str, TValue *o)
 {
   StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), o,
 				   STRSCAN_OPT_TONUM);
@@ -531,7 +531,7 @@ int LJ_FASTCALL lj_strscan_num(GCstr *str, TValue *o)
 }
 
 #if LJ_DUALNUM
-int LJ_FASTCALL lj_strscan_number(GCstr *str, TValue *o)
+int lj_strscan_number(GCstr *str, TValue *o)
 {
   StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), o,
 				   STRSCAN_OPT_TOINT);

--- a/src/lj_strscan.h
+++ b/src/lj_strscan.h
@@ -23,9 +23,9 @@ typedef enum {
 } StrScanFmt;
 
 LJ_FUNC StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt);
-LJ_FUNC int LJ_FASTCALL lj_strscan_num(GCstr *str, TValue *o);
+LJ_FUNC int lj_strscan_num(GCstr *str, TValue *o);
 #if LJ_DUALNUM
-LJ_FUNC int LJ_FASTCALL lj_strscan_number(GCstr *str, TValue *o);
+LJ_FUNC int lj_strscan_number(GCstr *str, TValue *o);
 #else
 #define lj_strscan_number(s, o)		lj_strscan_num((s), (o))
 #endif

--- a/src/lj_tab.c
+++ b/src/lj_tab.c
@@ -161,7 +161,7 @@ GCtab *lj_tab_new_ah(lua_State *L, int32_t a, int32_t h)
   return lj_tab_new(L, (uint32_t)(a > 0 ? a+1 : 0), hsize2hbits(h));
 }
 
-GCtab * LJ_FASTCALL lj_tab_new1(lua_State *L, uint32_t ahsize)
+GCtab * lj_tab_new1(lua_State *L, uint32_t ahsize)
 {
   GCtab *t = newtab(L, ahsize & 0xffffff, ahsize >> 24);
   clearapart(t);
@@ -170,7 +170,7 @@ GCtab * LJ_FASTCALL lj_tab_new1(lua_State *L, uint32_t ahsize)
 }
 
 /* Duplicate a table. */
-GCtab * LJ_FASTCALL lj_tab_dup(lua_State *L, const GCtab *kt)
+GCtab * lj_tab_dup(lua_State *L, const GCtab *kt)
 {
   GCtab *t;
   uint32_t asize, hmask;
@@ -209,7 +209,7 @@ GCtab * LJ_FASTCALL lj_tab_dup(lua_State *L, const GCtab *kt)
 }
 
 /* Clear a table. */
-void LJ_FASTCALL lj_tab_clear(GCtab *t)
+void lj_tab_clear(GCtab *t)
 {
   clearapart(t);
   if (t->hmask > 0) {
@@ -220,7 +220,7 @@ void LJ_FASTCALL lj_tab_clear(GCtab *t)
 }
 
 /* Free a table. */
-void LJ_FASTCALL lj_tab_free(global_State *g, GCtab *t)
+void lj_tab_free(global_State *g, GCtab *t)
 {
   if (t->hmask > 0)
     lj_mem_freevec(g, noderef(t->node), t->hmask+1, Node);
@@ -385,7 +385,7 @@ void lj_tab_reasize(lua_State *L, GCtab *t, uint32_t nasize)
 
 /* -- Table getters ------------------------------------------------------- */
 
-cTValue * LJ_FASTCALL lj_tab_getinth(GCtab *t, int32_t key)
+cTValue * lj_tab_getinth(GCtab *t, int32_t key)
 {
   TValue k;
   Node *n;
@@ -632,7 +632,7 @@ static MSize unbound_search(GCtab *t, MSize j)
 ** Try to find a boundary in table `t'. A `boundary' is an integer index
 ** such that t[i] is non-nil and t[i+1] is nil (and 0 if t[1] is nil).
 */
-MSize LJ_FASTCALL lj_tab_len(GCtab *t)
+MSize lj_tab_len(GCtab *t)
 {
   MSize j = (MSize)t->asize;
   if (j > 1 && tvisnil(arrayslot(t, j-1))) {

--- a/src/lj_tab.h
+++ b/src/lj_tab.h
@@ -28,17 +28,17 @@ static LJ_AINLINE uint32_t hashrot(uint32_t lo, uint32_t hi)
 
 LJ_FUNCA GCtab *lj_tab_new(lua_State *L, uint32_t asize, uint32_t hbits);
 LJ_FUNC GCtab *lj_tab_new_ah(lua_State *L, int32_t a, int32_t h);
-LJ_FUNC GCtab * LJ_FASTCALL lj_tab_new1(lua_State *L, uint32_t ahsize);
-LJ_FUNCA GCtab * LJ_FASTCALL lj_tab_dup(lua_State *L, const GCtab *kt);
-LJ_FUNC void LJ_FASTCALL lj_tab_clear(GCtab *t);
-LJ_FUNC void LJ_FASTCALL lj_tab_free(global_State *g, GCtab *t);
+LJ_FUNC GCtab * lj_tab_new1(lua_State *L, uint32_t ahsize);
+LJ_FUNCA GCtab * lj_tab_dup(lua_State *L, const GCtab *kt);
+LJ_FUNC void lj_tab_clear(GCtab *t);
+LJ_FUNC void lj_tab_free(global_State *g, GCtab *t);
 LJ_FUNC void lj_tab_rehash(lua_State *L, GCtab *t);
 LJ_FUNC void lj_tab_resize(lua_State *L, GCtab *t, uint32_t asize, uint32_t hbits);
 LJ_FUNCA void lj_tab_reasize(lua_State *L, GCtab *t, uint32_t nasize);
 
 /* Caveat: all getters except lj_tab_get() can return NULL! */
 
-LJ_FUNCA cTValue * LJ_FASTCALL lj_tab_getinth(GCtab *t, int32_t key);
+LJ_FUNCA cTValue * lj_tab_getinth(GCtab *t, int32_t key);
 LJ_FUNC cTValue *lj_tab_getstr(GCtab *t, GCstr *key);
 LJ_FUNCA cTValue *lj_tab_get(lua_State *L, GCtab *t, cTValue *key);
 
@@ -57,6 +57,6 @@ LJ_FUNC TValue *lj_tab_set(lua_State *L, GCtab *t, cTValue *key);
   (inarray((t), (key)) ? arrayslot((t), (key)) : lj_tab_setinth(L, (t), (key)))
 
 LJ_FUNCA int lj_tab_next(lua_State *L, GCtab *t, TValue *key);
-LJ_FUNCA MSize LJ_FASTCALL lj_tab_len(GCtab *t);
+LJ_FUNCA MSize lj_tab_len(GCtab *t);
 
 #endif

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -82,7 +82,7 @@ static TraceNo trace_findfree(jit_State *J)
   p += J->cur.szfield*sizeof(tp);
 
 /* Allocate space for copy of T. */
-GCtrace * LJ_FASTCALL lj_trace_alloc(lua_State *L, GCtrace *T)
+GCtrace * lj_trace_alloc(lua_State *L, GCtrace *T)
 {
   size_t sztr = ((sizeof(GCtrace)+7)&~7);
   size_t szins = (T->nins-T->nk)*sizeof(IRIns);
@@ -125,7 +125,7 @@ static void trace_save(jit_State *J, GCtrace *T)
   lj_gdbjit_addtrace(J, T);
 }
 
-void LJ_FASTCALL lj_trace_free(global_State *g, GCtrace *T)
+void lj_trace_free(global_State *g, GCtrace *T)
 {
   jit_State *J = G2J(g);
   if (T->traceno) {
@@ -664,7 +664,7 @@ void lj_trace_ins(jit_State *J, const BCIns *pc)
 }
 
 /* A hotcount triggered. Start recording a root trace. */
-void LJ_FASTCALL lj_trace_hot(jit_State *J, const BCIns *pc)
+void lj_trace_hot(jit_State *J, const BCIns *pc)
 {
   /* Note: pc is the interpreter bytecode PC here. It's offset by 1. */
   ERRNO_SAVE
@@ -697,7 +697,7 @@ static void trace_hotside(jit_State *J, const BCIns *pc)
 }
 
 /* Stitch a new trace to the previous trace. */
-void LJ_FASTCALL lj_trace_stitch(jit_State *J, const BCIns *pc)
+void lj_trace_stitch(jit_State *J, const BCIns *pc)
 {
   /* Only start a new trace if not recording or inside __gc call or vmevent. */
   if (J->state == LJ_TRACE_IDLE &&
@@ -744,7 +744,7 @@ static TraceNo trace_exit_find(jit_State *J, MCode *pc)
 #endif
 
 /* A trace exited. Restore interpreter state. */
-int LJ_FASTCALL lj_trace_exit(jit_State *J, void *exptr)
+int lj_trace_exit(jit_State *J, void *exptr)
 {
   ERRNO_SAVE
   lua_State *L = J->L;

--- a/src/lj_trace.h
+++ b/src/lj_trace.h
@@ -22,8 +22,8 @@ LJ_FUNC_NORET void lj_trace_err(jit_State *J, TraceError e);
 LJ_FUNC_NORET void lj_trace_err_info(jit_State *J, TraceError e);
 
 /* Trace management. */
-LJ_FUNC GCtrace * LJ_FASTCALL lj_trace_alloc(lua_State *L, GCtrace *T);
-LJ_FUNC void LJ_FASTCALL lj_trace_free(global_State *g, GCtrace *T);
+LJ_FUNC GCtrace * lj_trace_alloc(lua_State *L, GCtrace *T);
+LJ_FUNC void lj_trace_free(global_State *g, GCtrace *T);
 LJ_FUNC void lj_trace_reenableproto(GCproto *pt);
 LJ_FUNC void lj_trace_flushproto(global_State *g, GCproto *pt);
 LJ_FUNC void lj_trace_flush(jit_State *J, TraceNo traceno);
@@ -33,9 +33,9 @@ LJ_FUNC void lj_trace_freestate(global_State *g);
 
 /* Event handling. */
 LJ_FUNC void lj_trace_ins(jit_State *J, const BCIns *pc);
-LJ_FUNCA void LJ_FASTCALL lj_trace_hot(jit_State *J, const BCIns *pc);
-LJ_FUNCA void LJ_FASTCALL lj_trace_stitch(jit_State *J, const BCIns *pc);
-LJ_FUNCA int LJ_FASTCALL lj_trace_exit(jit_State *J, void *exptr);
+LJ_FUNCA void lj_trace_hot(jit_State *J, const BCIns *pc);
+LJ_FUNCA void lj_trace_stitch(jit_State *J, const BCIns *pc);
+LJ_FUNCA int lj_trace_exit(jit_State *J, void *exptr);
 
 /* Signal asynchronous abort of trace or end of trace. */
 #define lj_trace_abort(g)	(G2J(g)->state &= ~LJ_TRACE_ACTIVE)

--- a/src/lj_udata.c
+++ b/src/lj_udata.c
@@ -27,7 +27,7 @@ GCudata *lj_udata_new(lua_State *L, MSize sz, GCtab *env)
   return ud;
 }
 
-void LJ_FASTCALL lj_udata_free(global_State *g, GCudata *ud)
+void lj_udata_free(global_State *g, GCudata *ud)
 {
   lj_mem_free(g, ud, sizeudata(ud));
 }

--- a/src/lj_udata.h
+++ b/src/lj_udata.h
@@ -9,6 +9,6 @@
 #include "lj_obj.h"
 
 LJ_FUNC GCudata *lj_udata_new(lua_State *L, MSize sz, GCtab *env);
-LJ_FUNC void LJ_FASTCALL lj_udata_free(global_State *g, GCudata *ud);
+LJ_FUNC void lj_udata_free(global_State *g, GCudata *ud);
 
 #endif

--- a/src/lj_vm.h
+++ b/src/lj_vm.h
@@ -15,8 +15,8 @@ typedef TValue *(*lua_CPFunction)(lua_State *L, lua_CFunction func, void *ud);
 LJ_ASMF int lj_vm_cpcall(lua_State *L, lua_CFunction func, void *ud,
 			 lua_CPFunction cp);
 LJ_ASMF int lj_vm_resume(lua_State *L, TValue *base, int nres1, ptrdiff_t ef);
-LJ_ASMF_NORET void LJ_FASTCALL lj_vm_unwind_c(void *cframe, int errcode);
-LJ_ASMF_NORET void LJ_FASTCALL lj_vm_unwind_ff(void *cframe);
+LJ_ASMF_NORET void lj_vm_unwind_c(void *cframe, int errcode);
+LJ_ASMF_NORET void lj_vm_unwind_ff(void *cframe);
 LJ_ASMF void lj_vm_unwind_c_eh(void);
 LJ_ASMF void lj_vm_unwind_ff_eh(void);
 LJ_ASMF void lj_vm_unwind_rethrow(void);
@@ -48,7 +48,7 @@ LJ_ASMF double lj_vm_log2(double);
 #else
 #define lj_vm_log2	log2
 #endif
-LJ_ASMF int32_t LJ_FASTCALL lj_vm_modi(int32_t, int32_t);
+LJ_ASMF int32_t lj_vm_modi(int32_t, int32_t);
 
 LJ_ASMF void lj_vm_floor_sse(void);
 LJ_ASMF void lj_vm_ceil_sse(void);

--- a/src/lj_vmmath.c
+++ b/src/lj_vmmath.c
@@ -37,7 +37,7 @@ double lj_vm_foldarith(double x, double y, int op)
   }
 }
 
-int32_t LJ_FASTCALL lj_vm_modi(int32_t a, int32_t b)
+int32_t lj_vm_modi(int32_t a, int32_t b)
 {
   uint32_t y, ua, ub;
   lua_assert(b != 0);  /* This must be checked before using this function. */


### PR DESCRIPTION
The C macro `LJ_FASTCALL` is Dead Code that can be Eliminated. The automatic removal of non-Linux/x86-64 code in #5 had already made the definition empty - this PR removes the definition and all uses.

One less thing to worry about: No RaptorJIT hackers will never see `LJ_FASTCALL` and have to wonder what it means.

Thanks @javierguerragiraldez for explaining that this macro was to benefit i386 only!