### PR TITLE
Define build environment using nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: c
+language: nix
 sudo: false
 script:
-  - make
-  - src/luajit -e 'for i = 1, 1000 do end'
+  - nix-build
+  - result/bin/raptorjit -e 'for i = 1, 1000 do end'
   - git submodule init submodules/raptorjit-testsuite
-  - (cd submodules/raptorjit-testsuite/test; ../../../src/luajit test.lua)
+  - (cd submodules/raptorjit-testsuite/test; ../../../result/bin/raptorjit test.lua)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,35 @@ Initial changes (ongoing work):
 
 PRs welcome! Shock me with your radical ideas! :-)
 
+### Compilation
+
+RaptorJIT is built using GNU Make, Clang (C compiler), and LuaJIT 2 (bootstrap Lua for DynASM etc.) The build environment is specified formally in `default.nix` and can be automatically provided using the [nix](http://nixos.org/nix/) package manager.
+
+Here is how to install nix:
+
+```
+$ curl https://nixos.org/nix/install | sh
+```
+
+Here is how to build raptorjit once nix is installed (note: the first
+compilation takes time to download dependencies):
+
+```shell
+$ nix-build    # produces result/bin/raptorjit
+```
+
+Here is the interactive version:
+
+```
+$ nix-shell    # start sub-shell with pristine build environment in $PATH
+[nix-shell]$ make -j    # build manually as many times as you like
+[nix-shell]$ exit       # quit when done
+```
+
+(You can also skip `nix` and install `clang` and `luajit` yourself if
+you like. The nix approach is future proof to new dependencies and
+allows for pinning specific versions.)
+
 ### Quotes
 
 Here are some borrowed words to put this branch into context:

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{ pkgs ? (import <nixpkgs> {})
+, source ? ./.
+, version ? "dev"
+}:
+
+with pkgs;
+with clangStdenv;
+
+mkDerivation rec {
+  name = "raptorjit-${version}";
+  inherit version;
+  src = lib.cleanSource source;
+  enableParallelBuilding = true;
+  buildInputs = [ luajit ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp src/luajit $out/bin/raptorjit
+  '';
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -192,9 +192,7 @@ LDOPTIONS= $(CCDEBUG) $(LDFLAGS)
 
 HOST_CC= $(CC)
 HOST_RM= rm -f
-# If left blank, minilua is built and used. You can supply an installed
-# copy of (plain) Lua 5.1 or 5.2, plus Lua BitOp. E.g. with: HOST_LUA=lua
-HOST_LUA=
+HOST_LUA=luajit
 
 HOST_XCFLAGS= -I.
 HOST_XLDFLAGS=
@@ -373,16 +371,6 @@ endif
 # Files and pathnames.
 ##############################################################################
 
-MINILUA_O= host/minilua.o
-MINILUA_LIBS= -lm
-MINILUA_T= host/minilua
-MINILUA_X= $(MINILUA_T)
-
-ifeq (,$(HOST_LUA))
-  HOST_LUA= $(MINILUA_X)
-  DASM_DEP= $(MINILUA_T)
-endif
-
 DASM_DIR= ../dynasm
 DASM= $(HOST_LUA) $(DASM_DIR)/dynasm.lua
 DASM_XFLAGS=
@@ -464,8 +452,8 @@ BUILDVM_O= host/buildvm.o host/buildvm_asm.o host/buildvm_peobj.o \
 BUILDVM_T= host/buildvm
 BUILDVM_X= $(BUILDVM_T)
 
-HOST_O= $(MINILUA_O) $(BUILDVM_O)
-HOST_T= $(MINILUA_T) $(BUILDVM_T)
+HOST_O= $(BUILDVM_O)
+HOST_T= $(BUILDVM_T)
 
 LJVM_S= lj_vm.S
 LJVM_O= lj_vm.o
@@ -547,16 +535,6 @@ ifeq (PS3,$(TARGET_SYS))
   BUILDMODE= static
 endif
 
-ifeq (Windows,$(HOST_SYS))
-  MINILUA_T= host/minilua.exe
-  BUILDVM_T= host/buildvm.exe
-  ifeq (,$(HOST_MSYS))
-    MINILUA_X= host\minilua
-    BUILDVM_X= host\buildvm
-    ALL_RM:= $(subst /,\,$(ALL_RM))
-  endif
-endif
-
 ifeq (static,$(BUILDMODE))
   TARGET_DYNCC= @:
   TARGET_T= $(LUAJIT_T)
@@ -623,10 +601,6 @@ depend:
 ##############################################################################
 # Rules for generated files.
 ##############################################################################
-
-$(MINILUA_T): $(MINILUA_O)
-	$(E) "HOSTLINK  $@"
-	$(Q)$(HOST_CC) $(HOST_ALDFLAGS) -o $@ $(MINILUA_O) $(MINILUA_LIBS) $(HOST_ALIBS)
 
 host/buildvm_arch.h: $(DASM_DASC) $(DASM_DEP) $(DASM_DIR)/*.lua
 	$(E) "DYNASM    $@"

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ NODOTABIVER= 51
 # removing the '#' in front of them. Make sure you force a full recompile
 # with "make clean", followed by "make" if you change any options.
 #
-DEFAULT_CC = gcc
+DEFAULT_CC = clang
 #
 # LuaJIT builds as a native 32 or 64 bit binary by default.
 CC= $(DEFAULT_CC)


### PR DESCRIPTION
Formalize the build-time dependencies in `default.nix`. Requires `clang` as the host C compiler and `luajit` as the bootstrap Lua interpreter (for DynASM etc.) README is updated with instructions for setting up the build environment automatically using `nix`.

Resolves #23 #24 #25.