### PR TITLE
Remove DUALNUM mode

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -391,9 +391,6 @@ endif
 ifneq (,$(findstring LJ_HASFFI 1,$(TARGET_TESTARCH)))
   DASM_AFLAGS+= -D FFI
 endif
-ifneq (,$(findstring LJ_DUALNUM 1,$(TARGET_TESTARCH)))
-  DASM_AFLAGS+= -D DUALNUM
-endif
 ifneq (,$(findstring LJ_ARCH_HASFPU 1,$(TARGET_TESTARCH)))
   DASM_AFLAGS+= -D FPU
   TARGET_ARCH+= -DLJ_ARCH_HASFPU=1

--- a/src/host/buildvm_lib.c
+++ b/src/host/buildvm_lib.c
@@ -176,7 +176,7 @@ static void libdef_fixupbc(uint8_t *p)
     uint8_t ra = p[libbc_endian ? 2 : 1];
     uint8_t rc = p[libbc_endian ? 1 : 2];
     uint8_t rb = p[libbc_endian ? 0 : 3];
-    if (!LJ_DUALNUM && op == BC_ISTYPE && rc == ~LJ_TNUMX+1) {
+    if (op == BC_ISTYPE && rc == ~LJ_TNUMX+1) {
       op = BC_ISNUM; rc++;
     }
     p[LJ_ENDIAN_SELECT(0, 3)] = op;

--- a/src/ifdef-defile
+++ b/src/ifdef-defile
@@ -18,6 +18,7 @@
 #define LJ_64 1
 #define LJ_ARCH_BITS 64
 #define LJ_ARCH_ENDIAN == LUAJIT_LE
+#define LJ_DUALNUM 0
 #define LJ_FR2 1
 #define LJ_NUMMODE LJ_NUMMODE_SINGLE_DUAL
 #define LJ_NUMMODE_DUAL		2
@@ -47,6 +48,7 @@
 #define LUAJIT_ARCH_x64		2
 #define LUAJIT_ARCH_x86		1
 #define LUAJIT_LE 1
+#define LUAJIT_NUMMODE=1
 #define LUAJIT_OS LUAJIT_OS_LINUX
 #define LUAJIT_OS_LINUX 2
 #define LUAJIT_OS_WINDOWS 3

--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -264,13 +264,6 @@ LJLIB_ASM(tonumber)		LJLIB_REC(.)
       CType *ct = lj_ctype_rawref(cts, cdataV(o)->ctypeid);
       if (ctype_isenum(ct->info)) ct = ctype_child(cts, ct);
       if (ctype_isnum(ct->info) || ctype_iscomplex(ct->info)) {
-	if (LJ_DUALNUM && ctype_isinteger_or_bool(ct->info) &&
-	    ct->size <= 4 && !(ct->size == 4 && (ct->info & CTF_UNSIGNED))) {
-	  int32_t i;
-	  lj_cconv_ct_tv(cts, ctype_get(cts, CTID_INT32), (uint8_t *)&i, o, 0);
-	  setintV(L->base-1-LJ_FR2, i);
-	  return FFH_RES(1);
-	}
 	lj_cconv_ct_tv(cts, ctype_get(cts, CTID_DOUBLE),
 		       (uint8_t *)&(L->base-1-LJ_FR2)->n, o, 0);
 	return FFH_RES(1);
@@ -286,10 +279,7 @@ LJLIB_ASM(tonumber)		LJLIB_REC(.)
     if (p != ep) {
       while (lj_char_isspace((unsigned char)(*ep))) ep++;
       if (*ep == '\0') {
-	if (LJ_DUALNUM && LJ_LIKELY(ul < 0x80000000u))
-	  setintV(L->base-1-LJ_FR2, (int32_t)ul);
-	else
-	  setnumV(L->base-1-LJ_FR2, (lua_Number)ul);
+        setnumV(L->base-1-LJ_FR2, (lua_Number)ul);
 	return FFH_RES(1);
       }
     }

--- a/src/lib_io.c
+++ b/src/lib_io.c
@@ -120,13 +120,6 @@ static int io_file_readnum(lua_State *L, FILE *fp)
 {
   lua_Number d;
   if (fscanf(fp, LUA_NUMBER_SCAN, &d) == 1) {
-    if (LJ_DUALNUM) {
-      int32_t i = lj_num2int(d);
-      if (d == (lua_Number)i && !tvismzero((cTValue *)&d)) {
-	setintV(L->top++, i);
-	return 1;
-      }
-    }
     setnumV(L->top++, d);
     return 1;
   } else {
@@ -311,9 +304,7 @@ LJLIB_CF(io_method_seek)
   else if (opt == 2) opt = SEEK_END;
   o = L->base+2;
   if (o < L->top) {
-    if (tvisint(o))
-      ofs = (int64_t)intV(o);
-    else if (tvisnum(o))
+    if (tvisnum(o))
       ofs = (int64_t)numV(o);
     else if (!tvisnil(o))
       lj_err_argt(L, 3, LUA_TNUMBER);

--- a/src/lib_math.c
+++ b/src/lib_math.c
@@ -157,42 +157,13 @@ LJLIB_CF(math_random)		LJLIB_REC(.)
   u.u64 = lj_math_random_step(rs);
   d = u.d - 1.0;
   if (n > 0) {
-#if LJ_DUALNUM
-    int isint = 1;
-    double r1;
-    lj_lib_checknumber(L, 1);
-    if (tvisint(L->base)) {
-      r1 = (lua_Number)intV(L->base);
-    } else {
-      isint = 0;
-      r1 = numV(L->base);
-    }
-#else
     double r1 = lj_lib_checknum(L, 1);
-#endif
     if (n == 1) {
       d = lj_vm_floor(d*r1) + 1.0;  /* d is an int in range [1, r1] */
     } else {
-#if LJ_DUALNUM
-      double r2;
-      lj_lib_checknumber(L, 2);
-      if (tvisint(L->base+1)) {
-	r2 = (lua_Number)intV(L->base+1);
-      } else {
-	isint = 0;
-	r2 = numV(L->base+1);
-      }
-#else
       double r2 = lj_lib_checknum(L, 2);
-#endif
       d = lj_vm_floor(d*(r2-r1+1.0)) + r1;  /* d is an int in range [r1, r2] */
     }
-#if LJ_DUALNUM
-    if (isint) {
-      setintV(L->top-1, lj_num2int(d));
-      return 1;
-    }
-#endif
   }  /* else: d is a double in range [0, 1] */
   setnumV(L->top++, d);
   return 1;

--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -681,21 +681,10 @@ again:
 	luaL_argerror(L, arg, lj_obj_typename[0]);
       switch (STRFMT_TYPE(sf)) {
       case STRFMT_INT:
-	if (tvisint(L->base+arg-1)) {
-	  int32_t k = intV(L->base+arg-1);
-	  if (sf == STRFMT_INT)
-	    lj_strfmt_putint(sb, k);  /* Shortcut for plain %d. */
-	  else
-	    lj_strfmt_putfxint(sb, sf, k);
-	} else {
-	  lj_strfmt_putfnum_int(sb, sf, lj_lib_checknum(L, arg));
-	}
+        lj_strfmt_putfnum_int(sb, sf, lj_lib_checknum(L, arg));
 	break;
       case STRFMT_UINT:
-	if (tvisint(L->base+arg-1))
-	  lj_strfmt_putfxint(sb, sf, intV(L->base+arg-1));
-	else
-	  lj_strfmt_putfnum_uint(sb, sf, lj_lib_checknum(L, arg));
+        lj_strfmt_putfnum_uint(sb, sf, lj_lib_checknum(L, arg));
 	break;
       case STRFMT_NUM:
 	lj_strfmt_putfnum(sb, sf, lj_lib_checknum(L, arg));

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -253,9 +253,7 @@ LUA_API int lua_equal(lua_State *L, int idx1, int idx2)
 {
   cTValue *o1 = index2adr(L, idx1);
   cTValue *o2 = index2adr(L, idx2);
-  if (tvisint(o1) && tvisint(o2)) {
-    return intV(o1) == intV(o2);
-  } else if (tvisnumber(o1) && tvisnumber(o2)) {
+  if (tvisnumber(o1) && tvisnumber(o2)) {
     return numberVnum(o1) == numberVnum(o2);
   } else if (itype(o1) != itype(o2)) {
     return 0;
@@ -284,8 +282,6 @@ LUA_API int lua_lessthan(lua_State *L, int idx1, int idx2)
   cTValue *o2 = index2adr(L, idx2);
   if (o1 == niltv(L) || o2 == niltv(L)) {
     return 0;
-  } else if (tvisint(o1) && tvisint(o2)) {
-    return intV(o1) < intV(o2);
   } else if (tvisnumber(o1) && tvisnumber(o2)) {
     return numberVnum(o1) < numberVnum(o2);
   } else {
@@ -342,15 +338,11 @@ LUA_API lua_Integer lua_tointeger(lua_State *L, int idx)
   cTValue *o = index2adr(L, idx);
   TValue tmp;
   lua_Number n;
-  if (LJ_LIKELY(tvisint(o))) {
-    return intV(o);
-  } else if (LJ_LIKELY(tvisnum(o))) {
+  if (LJ_LIKELY(tvisnum(o))) {
     n = numV(o);
   } else {
     if (!(tvisstr(o) && lj_strscan_number(strV(o), &tmp)))
       return 0;
-    if (tvisint(&tmp))
-      return (lua_Integer)intV(&tmp);
     n = numV(&tmp);
   }
   return (lua_Integer)n;
@@ -361,15 +353,11 @@ LUALIB_API lua_Integer luaL_checkinteger(lua_State *L, int idx)
   cTValue *o = index2adr(L, idx);
   TValue tmp;
   lua_Number n;
-  if (LJ_LIKELY(tvisint(o))) {
-    return intV(o);
-  } else if (LJ_LIKELY(tvisnum(o))) {
+  if (LJ_LIKELY(tvisnum(o))) {
     n = numV(o);
   } else {
     if (!(tvisstr(o) && lj_strscan_number(strV(o), &tmp)))
       lj_err_argt(L, idx, LUA_TNUMBER);
-    if (tvisint(&tmp))
-      return (lua_Integer)intV(&tmp);
     n = numV(&tmp);
   }
   return (lua_Integer)n;
@@ -380,17 +368,13 @@ LUALIB_API lua_Integer luaL_optinteger(lua_State *L, int idx, lua_Integer def)
   cTValue *o = index2adr(L, idx);
   TValue tmp;
   lua_Number n;
-  if (LJ_LIKELY(tvisint(o))) {
-    return intV(o);
-  } else if (LJ_LIKELY(tvisnum(o))) {
+  if (LJ_LIKELY(tvisnum(o))) {
     n = numV(o);
   } else if (tvisnil(o)) {
     return def;
   } else {
     if (!(tvisstr(o) && lj_strscan_number(strV(o), &tmp)))
       lj_err_argt(L, idx, LUA_TNUMBER);
-    if (tvisint(&tmp))
-      return (lua_Integer)intV(&tmp);
     n = numV(&tmp);
   }
   return (lua_Integer)n;

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -57,11 +57,6 @@
 
 
 
-#define LJ_NUMMODE_SINGLE	0	/* Single-number mode only. */
-#define LJ_NUMMODE_SINGLE_DUAL	1	/* Default to single-number mode. */
-#define LJ_NUMMODE_DUAL		2	/* Dual-number mode only. */
-#define LJ_NUMMODE_DUAL_SINGLE	3	/* Default to dual-number mode. */
-
 /* Set target architecture properties. */
 
 #define LJ_ARCH_NAME		"x64"
@@ -75,7 +70,6 @@
 #define LJ_TARGET_MASKSHIFT	1
 #define LJ_TARGET_MASKROT	1
 #define LJ_TARGET_UNALIGNED	1
-#define LJ_ARCH_NUMMODE		LJ_NUMMODE_SINGLE_DUAL
 #define LJ_TARGET_GC64		1
 
 
@@ -96,20 +90,6 @@
 #error "Need a C compiler with native exception handling on x64"
 #endif
 #endif
-
-/* Enable or disable the dual-number mode for the VM. */
-#if (LJ_ARCH_NUMMODE == LJ_NUMMODE_SINGLE && LUAJIT_NUMMODE == 2) || \
-    (LJ_ARCH_NUMMODE == LJ_NUMMODE_DUAL && LUAJIT_NUMMODE == 1)
-#error "No support for this number mode on this architecture"
-#endif
-#if LJ_ARCH_NUMMODE == LJ_NUMMODE_DUAL || \
-    (LJ_ARCH_NUMMODE == LJ_NUMMODE_DUAL_SINGLE && LUAJIT_NUMMODE != 1) || \
-    (LJ_ARCH_NUMMODE == LJ_NUMMODE_SINGLE_DUAL && LUAJIT_NUMMODE == 2)
-#define LJ_DUALNUM		1
-#else
-#define LJ_DUALNUM		0
-#endif
-
 
 /* 64 bit GC references. */
 #define LJ_GC64			1

--- a/src/lj_buf.c
+++ b/src/lj_buf.c
@@ -173,8 +173,6 @@ SBuf *lj_buf_puttab(SBuf *sb, GCtab *t, GCstr *sep, int32_t i, int32_t e)
       } else if (tvisstr(o)) {
 	MSize len = strV(o)->len;
 	p = lj_buf_wmem(lj_buf_more(sb, len + seplen), strVdata(o), len);
-      } else if (tvisint(o)) {
-	p = lj_strfmt_wint(lj_buf_more(sb, STRFMT_MAXBUF_INT+seplen), intV(o));
       } else if (tvisnum(o)) {
 	p = lj_buf_more(lj_strfmt_putfnum(sb, STRFMT_G14, numV(o)), seplen);
       } else {

--- a/src/lj_carith.c
+++ b/src/lj_carith.c
@@ -50,9 +50,6 @@ static int carith_checkarg(lua_State *L, CTState *cts, CDArith *ca)
       if (ctype_isenum(ct->info)) ct = ctype_child(cts, ct);
       ca->ct[i] = ct;
       ca->p[i] = p;
-    } else if (tvisint(o)) {
-      ca->ct[i] = ctype_get(cts, CTID_INT32);
-      ca->p[i] = (uint8_t *)&o->i;
     } else if (tvisnum(o)) {
       ca->ct[i] = ctype_get(cts, CTID_DOUBLE);
       ca->p[i] = (uint8_t *)&o->n;
@@ -331,13 +328,8 @@ uint64_t lj_carith_check64(lua_State *L, int narg, CTypeID *id)
   } else if (!(tvisstr(o) && lj_strscan_number(strV(o), o))) {
     goto err;
   }
-  if (LJ_LIKELY(tvisint(o))) {
-    return (uint32_t)intV(o);
-  } else {
-    int32_t i = lj_num2bit(numV(o));
-    if (LJ_DUALNUM) setintV(o, i);
-    return (uint32_t)i;
-  }
+  int32_t i = lj_num2bit(numV(o));
+  return (uint32_t)i;
 }
 
 

--- a/src/lj_cconv.c
+++ b/src/lj_cconv.c
@@ -376,20 +376,10 @@ int lj_cconv_tv_ct(CTState *cts, CType *s, CTypeID sid,
   if (ctype_isnum(sinfo)) {
     if (!ctype_isbool(sinfo)) {
       if (ctype_isinteger(sinfo) && s->size > 4) goto copyval;
-      if (LJ_DUALNUM && ctype_isinteger(sinfo)) {
-	int32_t i;
-	lj_cconv_ct_ct(cts, ctype_get(cts, CTID_INT32), s,
-		       (uint8_t *)&i, sp, 0);
-	if ((sinfo & CTF_UNSIGNED) && i < 0)
-	  setnumV(o, (lua_Number)(uint32_t)i);
-	else
-	  setintV(o, i);
-      } else {
-	lj_cconv_ct_ct(cts, ctype_get(cts, CTID_DOUBLE), s,
-		       (uint8_t *)&o->n, sp, 0);
-	/* Numbers are NOT canonicalized here! Beware of uninitialized data. */
-	lua_assert(tvisnum(o));
-      }
+      lj_cconv_ct_ct(cts, ctype_get(cts, CTID_DOUBLE), s,
+                     (uint8_t *)&o->n, sp, 0);
+      /* Numbers are NOT canonicalized here! Beware of uninitialized data. */
+      lua_assert(tvisnum(o));
     } else {
       uint32_t b = s->size == 1 ? (*sp != 0) : (*(int *)sp != 0);
       setboolV(o, b);
@@ -441,7 +431,7 @@ int lj_cconv_tv_bf(CTState *cts, CType *s, TValue *o, uint8_t *sp)
       setintV(o, (int32_t)(val << (shift-pos)) >> shift);
     } else {
       val = (val << (shift-pos)) >> shift;
-      if (!LJ_DUALNUM || (int32_t)val < 0)
+      if ((int32_t)val < 0)
 	setnumV(o, (lua_Number)(uint32_t)val);
       else
 	setintV(o, (int32_t)val);
@@ -537,11 +527,7 @@ void lj_cconv_ct_tv(CTState *cts, CType *d,
   CType *s;
   void *tmpptr;
   uint8_t tmpbool, *sp = (uint8_t *)&tmpptr;
-  if (LJ_LIKELY(tvisint(o))) {
-    sp = (uint8_t *)&o->i;
-    sid = CTID_INT32;
-    flags |= CCF_FROMTV;
-  } else if (LJ_LIKELY(tvisnum(o))) {
+  if (LJ_LIKELY(tvisnum(o))) {
     sp = (uint8_t *)&o->n;
     sid = CTID_DOUBLE;
     flags |= CCF_FROMTV;

--- a/src/lj_cdata.c
+++ b/src/lj_cdata.c
@@ -127,10 +127,7 @@ collect_attrib:
   }
   lua_assert(!ctype_isref(ct->info));  /* Interning rejects refs to refs. */
 
-  if (tvisint(key)) {
-    idx = (ptrdiff_t)intV(key);
-    goto integer_key;
-  } else if (tvisnum(key)) {  /* Numeric key. */
+  if (tvisnum(key)) {  /* Numeric key. */
     lua_Number n = numV(key);
     idx = LJ_64 ? (ptrdiff_t)n : (ptrdiff_t)lj_num2int(n);
   integer_key:

--- a/src/lj_crecord.c
+++ b/src/lj_crecord.c
@@ -596,10 +596,10 @@ static TRef crec_ct_tv(jit_State *J, CType *d, TRef dp, TRef sp, cTValue *sval)
   CType *s;
   if (LJ_LIKELY(tref_isinteger(sp))) {
     sid = CTID_INT32;
-    svisnz = (void *)(intptr_t)(tvisint(sval)?(intV(sval)!=0):!tviszero(sval));
+    svisnz = (void *)(intptr_t)!tviszero(sval);
   } else if (tref_isnum(sp)) {
     sid = CTID_DOUBLE;
-    svisnz = (void *)(intptr_t)(tvisint(sval)?(intV(sval)!=0):!tviszero(sval));
+    svisnz = (void *)(intptr_t)!tviszero(sval);
   } else if (tref_isbool(sp)) {
     sp = lj_ir_kint(J, tref_istrue(sp) ? 1 : 0);
     sid = CTID_BOOL;

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -67,7 +67,7 @@ static int32_t argv2int(jit_State *J, TValue *o)
 {
   if (!lj_strscan_numberobj(o))
     lj_trace_err(J, LJ_TRERR_BADTYPE);
-  return tvisint(o) ? intV(o) : lj_num2int(numV(o));
+  return lj_num2int(numV(o));
 }
 
 /* Get runtime value of string argument. */
@@ -510,11 +510,6 @@ static void recff_math_round(jit_State *J, RecordFFData *rd)
   if (!tref_isinteger(tr)) {  /* Pass through integers unmodified. */
     tr = emitir(IRTN(IR_FPMATH), lj_ir_tonum(J, tr), rd->data);
     /* Result is integral (or NaN/Inf), but may not fit an int32_t. */
-    if (LJ_DUALNUM) {  /* Try to narrow using a guarded conversion to int. */
-      lua_Number n = lj_vm_foldfpm(numberVnum(&rd->argv[0]), rd->data);
-      if (n == (lua_Number)lj_num2int(n))
-	tr = emitir(IRTGI(IR_CONV), tr, IRCONV_INT_NUM|IRCONV_CHECK);
-    }
     J->base[0] = tr;
   }
 }

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -389,9 +389,7 @@ LJ_DATA const uint8_t lj_ir_type_size[];
 
 static LJ_AINLINE IRType itype2irt(const TValue *tv)
 {
-  if (tvisint(tv))
-    return IRT_INT;
-  else if (tvisnum(tv))
+  if (tvisnum(tv))
     return IRT_NUM;
   else
     return (IRType)~itype(tv);
@@ -400,12 +398,8 @@ static LJ_AINLINE IRType itype2irt(const TValue *tv)
 static LJ_AINLINE uint32_t irt_toitype_(IRType t)
 {
   lua_assert(!LJ_64 || LJ_GC64 || t != IRT_LIGHTUD);
-  if (LJ_DUALNUM && t > IRT_NUM) {
-    return LJ_TISNUM;
-  } else {
-    lua_assert(t <= IRT_NUM);
-    return ~(uint32_t)t;
-  }
+  lua_assert(t <= IRT_NUM);
+  return ~(uint32_t)t;
 }
 
 #define irt_toitype(t)		irt_toitype_(irt_type((t)))

--- a/src/lj_lex.c
+++ b/src/lj_lex.c
@@ -98,11 +98,8 @@ static void lex_number(LexState *ls, TValue *tv)
   }
   lex_save(ls, '\0');
   fmt = lj_strscan_scan((const uint8_t *)sbufB(&ls->sb), tv,
-	  (LJ_DUALNUM ? STRSCAN_OPT_TOINT : STRSCAN_OPT_TONUM) |
-	  (LJ_HASFFI ? (STRSCAN_OPT_LL|STRSCAN_OPT_IMAG) : 0));
-  if (LJ_DUALNUM && fmt == STRSCAN_INT) {
-    setitype(tv, LJ_TISNUM);
-  } else if (fmt == STRSCAN_NUM) {
+                        STRSCAN_OPT_TONUM|STRSCAN_OPT_LL|STRSCAN_OPT_IMAG);
+  if (fmt == STRSCAN_NUM) {
     /* Already in correct format. */
   } else if (fmt != STRSCAN_ERROR) {
     lua_State *L = ls->L;

--- a/src/lj_lib.c
+++ b/src/lj_lib.c
@@ -211,14 +211,6 @@ GCstr *lj_lib_optstr(lua_State *L, int narg)
   return (o < L->top && !tvisnil(o)) ? lj_lib_checkstr(L, narg) : NULL;
 }
 
-#if LJ_DUALNUM
-void lj_lib_checknumber(lua_State *L, int narg)
-{
-  TValue *o = L->base + narg-1;
-  if (!(o < L->top && lj_strscan_numberobj(o)))
-    lj_err_argt(L, narg, LUA_TNUMBER);
-}
-#endif
 
 lua_Number lj_lib_checknum(lua_State *L, int narg)
 {
@@ -226,13 +218,7 @@ lua_Number lj_lib_checknum(lua_State *L, int narg)
   if (!(o < L->top &&
 	(tvisnumber(o) || (tvisstr(o) && lj_strscan_num(strV(o), o)))))
     lj_err_argt(L, narg, LUA_TNUMBER);
-  if (LJ_UNLIKELY(tvisint(o))) {
-    lua_Number n = (lua_Number)intV(o);
-    setnumV(o, n);
-    return n;
-  } else {
-    return numV(o);
-  }
+  return numV(o);
 }
 
 int32_t lj_lib_checkint(lua_State *L, int narg)
@@ -240,13 +226,8 @@ int32_t lj_lib_checkint(lua_State *L, int narg)
   TValue *o = L->base + narg-1;
   if (!(o < L->top && lj_strscan_numberobj(o)))
     lj_err_argt(L, narg, LUA_TNUMBER);
-  if (LJ_LIKELY(tvisint(o))) {
-    return intV(o);
-  } else {
-    int32_t i = lj_num2int(numV(o));
-    if (LJ_DUALNUM) setintV(o, i);
-    return i;
-  }
+  int32_t i = lj_num2int(numV(o));
+  return i;
 }
 
 int32_t lj_lib_optint(lua_State *L, int narg, int32_t def)

--- a/src/lj_lib.h
+++ b/src/lj_lib.h
@@ -33,11 +33,7 @@
 LJ_FUNC TValue *lj_lib_checkany(lua_State *L, int narg);
 LJ_FUNC GCstr *lj_lib_checkstr(lua_State *L, int narg);
 LJ_FUNC GCstr *lj_lib_optstr(lua_State *L, int narg);
-#if LJ_DUALNUM
-LJ_FUNC void lj_lib_checknumber(lua_State *L, int narg);
-#else
 #define lj_lib_checknumber(L, narg)	lj_lib_checknum((L), (narg))
-#endif
 LJ_FUNC lua_Number lj_lib_checknum(lua_State *L, int narg);
 LJ_FUNC int32_t lj_lib_checkint(lua_State *L, int narg);
 LJ_FUNC int32_t lj_lib_optint(lua_State *L, int narg, int32_t def);

--- a/src/lj_meta.c
+++ b/src/lj_meta.c
@@ -175,7 +175,6 @@ TValue *lj_meta_tset(lua_State *L, cTValue *o, cTValue *k)
 	if (tv != niltv(L))
 	  return (TValue *)tv;
 	if (tvisnil(k)) lj_err_msg(L, LJ_ERR_NILIDX);
-	else if (tvisint(k)) { setnumV(&tmp, (lua_Number)intV(k)); k = &tmp; }
 	else if (tvisnum(k) && tvisnan(k)) lj_err_msg(L, LJ_ERR_NANIDX);
 	return lj_tab_newkey(L, t, k);
       }
@@ -199,8 +198,6 @@ static cTValue *str2num(cTValue *o, TValue *n)
 {
   if (tvisnum(o))
     return o;
-  else if (tvisint(o))
-    return (setnumV(n, (lua_Number)intV(o)), n);
   else if (tvisstr(o) && lj_strscan_num(strV(o), n))
     return n;
   else
@@ -288,8 +285,6 @@ TValue *lj_meta_cat(lua_State *L, TValue *top, int left)
 	  GCstr *s = strV(o);
 	  MSize len = s->len;
 	  lj_buf_putmem(sb, strdata(s), len);
-	} else if (tvisint(o)) {
-	  lj_strfmt_putint(sb, intV(o));
 	} else {
 	  lj_strfmt_putfnum(sb, STRFMT_G14, numV(o));
 	}
@@ -422,9 +417,8 @@ void lj_meta_istype(lua_State *L, BCReg ra, BCReg tp)
 {
   L->top = curr_topL(L);
   ra++; tp--;
-  lua_assert(LJ_DUALNUM || tp != ~LJ_TNUMX);  /* ISTYPE -> ISNUM broken. */
-  if (LJ_DUALNUM && tp == ~LJ_TNUMX) lj_lib_checkint(L, ra);
-  else if (tp == ~LJ_TNUMX+1) lj_lib_checknum(L, ra);
+  lua_assert(tp != ~LJ_TNUMX);  /* ISTYPE -> ISNUM broken. */
+  if (tp == ~LJ_TNUMX+1) lj_lib_checknum(L, ra);
   else if (tp == ~LJ_TSTR) lj_lib_checkstr(L, ra);
   else lj_err_argtype(L, ra, lj_obj_itypename[tp]);
 }
@@ -447,27 +441,5 @@ void lj_meta_for(lua_State *L, TValue *o)
   if (!lj_strscan_numberobj(o)) lj_err_msg(L, LJ_ERR_FORINIT);
   if (!lj_strscan_numberobj(o+1)) lj_err_msg(L, LJ_ERR_FORLIM);
   if (!lj_strscan_numberobj(o+2)) lj_err_msg(L, LJ_ERR_FORSTEP);
-  if (LJ_DUALNUM) {
-    /* Ensure all slots are integers or all slots are numbers. */
-    int32_t k[3];
-    int nint = 0;
-    ptrdiff_t i;
-    for (i = 0; i <= 2; i++) {
-      if (tvisint(o+i)) {
-	k[i] = intV(o+i); nint++;
-      } else {
-	k[i] = lj_num2int(numV(o+i)); nint += ((lua_Number)k[i] == numV(o+i));
-      }
-    }
-    if (nint == 3) {  /* Narrow to integers. */
-      setintV(o, k[0]);
-      setintV(o+1, k[1]);
-      setintV(o+2, k[2]);
-    } else if (nint != 0) {  /* Widen to numbers. */
-      if (tvisint(o)) setnumV(o, (lua_Number)intV(o));
-      if (tvisint(o+1)) setnumV(o+1, (lua_Number)intV(o+1));
-      if (tvisint(o+2)) setnumV(o+2, (lua_Number)intV(o+2));
-    }
-  }
 }
 

--- a/src/lj_opt_mem.c
+++ b/src/lj_opt_mem.c
@@ -182,8 +182,7 @@ static TRef fwd_ahload(jit_State *J, IRRef xref)
       lua_assert(ir->o != IR_TNEW || irt_isnil(fins->t));
       if (irt_ispri(fins->t)) {
 	return TREF_PRI(irt_type(fins->t));
-      } else if (irt_isnum(fins->t) || (irt_isint(fins->t)) ||
-		 irt_isstr(fins->t)) {
+      } else if (irt_isnum(fins->t) || irt_isstr(fins->t)) {
 	TValue keyv;
 	cTValue *tv;
 	IRIns *key = IR(xr->op2);

--- a/src/lj_opt_mem.c
+++ b/src/lj_opt_mem.c
@@ -182,7 +182,7 @@ static TRef fwd_ahload(jit_State *J, IRRef xref)
       lua_assert(ir->o != IR_TNEW || irt_isnil(fins->t));
       if (irt_ispri(fins->t)) {
 	return TREF_PRI(irt_type(fins->t));
-      } else if (irt_isnum(fins->t) || (LJ_DUALNUM && irt_isint(fins->t)) ||
+      } else if (irt_isnum(fins->t) || (irt_isint(fins->t)) ||
 		 irt_isstr(fins->t)) {
 	TValue keyv;
 	cTValue *tv;
@@ -193,8 +193,6 @@ static TRef fwd_ahload(jit_State *J, IRRef xref)
 	lua_assert(itype2irt(tv) == irt_type(fins->t));
 	if (irt_isnum(fins->t))
 	  return lj_ir_knum_u64(J, tv->u64);
-	else if (LJ_DUALNUM && irt_isint(fins->t))
-	  return lj_ir_kint(J, intV(tv));
 	else
 	  return lj_ir_kstr(J, strV(tv));
       }

--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -292,6 +292,9 @@ static TRef find_kinit(jit_State *J, const BCIns *endpc, BCReg slot, IRType t)
 	} else {
 	  cTValue *tv = proto_knumtv(J->pt, bc_d(ins));
 	  if (t == IRT_INT) {
+	    int32_t k = numberVint(tv);
+	    if (numV(tv) == (lua_Number)k)  /* -0 is ok here. */
+	      return lj_ir_kint(J, k);
 	    return 0;  /* Type mismatch. */
 	  } else {
 	    return lj_ir_knum(J, numberVnum(tv));

--- a/src/lj_snap.c
+++ b/src/lj_snap.c
@@ -84,7 +84,8 @@ static MSize snapshot_slots(jit_State *J, SnapEntry *map, BCReg nslots)
 	if (!(ir->op2 & IRSLOAD_INHERIT))
 	  continue;
 	/* No need to restore readonly slots and unmodified non-parent slots. */
-        sn |= SNAP_NORESTORE;
+	if ((ir->op2 & (IRSLOAD_READONLY|IRSLOAD_PARENT)) != IRSLOAD_PARENT)
+          sn |= SNAP_NORESTORE;
       }
       if (LJ_SOFTFP && irt_isnum(ir->t))
 	sn |= SNAP_SOFTFPNUM;

--- a/src/lj_snap.c
+++ b/src/lj_snap.c
@@ -84,9 +84,7 @@ static MSize snapshot_slots(jit_State *J, SnapEntry *map, BCReg nslots)
 	if (!(ir->op2 & IRSLOAD_INHERIT))
 	  continue;
 	/* No need to restore readonly slots and unmodified non-parent slots. */
-	if (!(LJ_DUALNUM && (ir->op2 & IRSLOAD_CONVERT)) &&
-	    (ir->op2 & (IRSLOAD_READONLY|IRSLOAD_PARENT)) != IRSLOAD_PARENT)
-	  sn |= SNAP_NORESTORE;
+        sn |= SNAP_NORESTORE;
       }
       if (LJ_SOFTFP && irt_isnum(ir->t))
 	sn |= SNAP_SOFTFPNUM;
@@ -621,7 +619,6 @@ static void snap_restoreval(jit_State *J, GCtrace *T, ExitState *ex,
     if (ra_noreg(r)) {
       lua_assert(ir->o == IR_CONV && ir->op2 == IRCONV_NUM_INT);
       snap_restoreval(J, T, ex, snapno, rfilt, ir->op1, o);
-      if (LJ_DUALNUM) setnumV(o, (lua_Number)intV(o));
       return;
     } else if (irt_isinteger(t)) {
       setintV(o, (int32_t)ex->gpr[r-RID_MIN_GPR]);
@@ -816,11 +813,6 @@ const BCIns *lj_snap_restore(jit_State *J, void *exptr)
 	continue;
       }
       snap_restoreval(J, T, ex, snapno, rfilt, ref, o);
-      if (LJ_SOFTFP && (sn & SNAP_SOFTFPNUM) && tvisint(o)) {
-	TValue tmp;
-	snap_restoreval(J, T, ex, snapno, rfilt, ref+1, &tmp);
-	o->u32.hi = tmp.u32.lo;
-      }
     }
   }
   L->base += (map[nent+LJ_BE] & 0xff);

--- a/src/lj_strfmt.c
+++ b/src/lj_strfmt.c
@@ -159,8 +159,6 @@ const char *lj_strfmt_wstrnum(lua_State *L, cTValue *o, MSize *lenp)
   if (tvisstr(o)) {
     *lenp = strV(o)->len;
     return strVdata(o);
-  } else if (tvisint(o)) {
-    sb = lj_strfmt_putint(lj_buf_tmp_(L), intV(o));
   } else if (tvisnum(o)) {
     sb = lj_strfmt_putfnum(lj_buf_tmp_(L), STRFMT_G14, o->n);
   } else {
@@ -355,7 +353,7 @@ GCstr * lj_strfmt_int(lua_State *L, int32_t k)
 /* Convert integer or number to string. */
 GCstr * lj_strfmt_number(lua_State *L, cTValue *o)
 {
-  return tvisint(o) ? lj_strfmt_int(L, intV(o)) : lj_strfmt_num(L, o);
+  return lj_strfmt_num(L, o);
 }
 
 /* Convert char value to string. */

--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -530,16 +530,6 @@ int lj_strscan_num(GCstr *str, TValue *o)
   return (fmt != STRSCAN_ERROR);
 }
 
-#if LJ_DUALNUM
-int lj_strscan_number(GCstr *str, TValue *o)
-{
-  StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), o,
-				   STRSCAN_OPT_TOINT);
-  lua_assert(fmt == STRSCAN_ERROR || fmt == STRSCAN_NUM || fmt == STRSCAN_INT);
-  if (fmt == STRSCAN_INT) setitype(o, LJ_TISNUM);
-  return (fmt != STRSCAN_ERROR);
-}
-#endif
 
 #undef DNEXT
 #undef DPREV

--- a/src/lj_strscan.h
+++ b/src/lj_strscan.h
@@ -24,11 +24,7 @@ typedef enum {
 
 LJ_FUNC StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt);
 LJ_FUNC int lj_strscan_num(GCstr *str, TValue *o);
-#if LJ_DUALNUM
-LJ_FUNC int lj_strscan_number(GCstr *str, TValue *o);
-#else
 #define lj_strscan_number(s, o)		lj_strscan_num((s), (o))
-#endif
 
 /* Check for number or convert string to number/int in-place (!). */
 static LJ_AINLINE int lj_strscan_numberobj(TValue *o)

--- a/src/lj_tab.c
+++ b/src/lj_tab.c
@@ -34,7 +34,6 @@ static LJ_AINLINE Node *hashmask(const GCtab *t, uint32_t hash)
 /* Hash an arbitrary key and return its anchor position in the hash table. */
 static Node *hashkey(const GCtab *t, cTValue *key)
 {
-  lua_assert(!tvisint(key));
   if (tvisstr(key))
     return hashstr(t, strV(key));
   else if (tvisnum(key))
@@ -298,7 +297,6 @@ void lj_tab_resize(lua_State *L, GCtab *t, uint32_t asize, uint32_t hbits)
 
 static uint32_t countint(cTValue *key, uint32_t *bins)
 {
-  lua_assert(!tvisint(key));
   if (tvisnum(key)) {
     lua_Number nk = numV(key);
     int32_t k = lj_num2int(nk);
@@ -414,10 +412,6 @@ cTValue *lj_tab_get(lua_State *L, GCtab *t, cTValue *key)
     cTValue *tv = lj_tab_getstr(t, strV(key));
     if (tv)
       return tv;
-  } else if (tvisint(key)) {
-    cTValue *tv = lj_tab_getint(t, intV(key));
-    if (tv)
-      return tv;
   } else if (tvisnum(key)) {
     lua_Number nk = numV(key);
     int32_t k = lj_num2int(nk);
@@ -526,8 +520,6 @@ TValue *lj_tab_set(lua_State *L, GCtab *t, cTValue *key)
   t->nomm = 0;  /* Invalidate negative metamethod cache. */
   if (tvisstr(key)) {
     return lj_tab_setstr(L, t, strV(key));
-  } else if (tvisint(key)) {
-    return lj_tab_setint(L, t, intV(key));
   } else if (tvisnum(key)) {
     lua_Number nk = numV(key);
     int32_t k = lj_num2int(nk);
@@ -552,14 +544,7 @@ TValue *lj_tab_set(lua_State *L, GCtab *t, cTValue *key)
 /* Get the traversal index of a key. */
 static uint32_t keyindex(lua_State *L, GCtab *t, cTValue *key)
 {
-  TValue tmp;
-  if (tvisint(key)) {
-    int32_t k = intV(key);
-    if ((uint32_t)k < t->asize)
-      return (uint32_t)k;  /* Array key indexes: [0..t->asize-1] */
-    setnumV(&tmp, (lua_Number)k);
-    key = &tmp;
-  } else if (tvisnum(key)) {
+  if (tvisnum(key)) {
     lua_Number nk = numV(key);
     int32_t k = lj_num2int(nk);
     if ((uint32_t)k < t->asize && nk == (lua_Number)k)

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -498,7 +498,6 @@ static int trace_abort(jit_State *J)
   /* Is there anything to abort? */
   traceno = J->cur.traceno;
   if (traceno) {
-    ptrdiff_t errobj = savestack(L, L->top-1);  /* Stack may be resized. */
     J->cur.link = 0;
     J->cur.linktype = LJ_TRLINK_NONE;
     /* Drop aborted trace after the vmevent (which may still access it).
@@ -692,7 +691,6 @@ int lj_trace_exit(jit_State *J, void *exptr)
 {
   ERRNO_SAVE
   lua_State *L = J->L;
-  ExitState *ex = (ExitState *)exptr;
   ExitDataCP exd;
   int errcode;
   const BCIns *pc;

--- a/src/vm_x64.dasc
+++ b/src/vm_x64.dasc
@@ -3935,10 +3935,15 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     vk = (op == BC_IFORL || op == BC_JFORL);
     |  ins_AJ	// RA = base, RD = target (after end of loop or start of loop)
     |  lea RA, [BASE+RA*8]
+    if (!vk) {
+      |  checknumtp FOR_IDX, ->vmeta_for
+      |  checknumtp FOR_STOP, ->vmeta_for
+    } else {
 #ifdef LUA_USE_ASSERT
-    |  checknumtp FOR_STOP, ->assert_bad_for_arg_type
-    |  checknumtp FOR_STEP, ->assert_bad_for_arg_type
+      |  checknumtp FOR_STOP, ->assert_bad_for_arg_type
+      |  checknumtp FOR_STEP, ->assert_bad_for_arg_type
 #endif
+    }
     |  mov RB, FOR_STEP
     if (!vk) {
       |  checknum RB, ->vmeta_for

--- a/src/vm_x64.dasc
+++ b/src/vm_x64.dasc
@@ -736,13 +736,8 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |->vmeta_tgetb:
   |  movzx RCd, PC_RC
-  |.if DUALNUM
-  |  setint RC
-  |  mov TMP1, RC
-  |.else
   |  cvtsi2sd xmm0, RCd
   |  movsd TMP1, xmm0
-  |.endif
   |  lea RC, TMP1
   |  jmp >1
   |
@@ -809,13 +804,8 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |->vmeta_tsetb:
   |  movzx RCd, PC_RC
-  |.if DUALNUM
-  |  setint RC
-  |  mov TMP1, RC
-  |.else
   |  cvtsi2sd xmm0, RCd
   |  movsd TMP1, xmm0
-  |.endif
   |  lea RC, TMP1
   |  jmp >1
   |
@@ -975,19 +965,11 @@ static void build_subroutines(BuildCtx *ctx)
   |//-- Arithmetic metamethods ---------------------------------------------
   |
   |->vmeta_arith_vno:
-  |.if DUALNUM
-  |  movzx RBd, PC_RB
-  |  movzx RCd, PC_RC
-  |.endif
   |->vmeta_arith_vn:
   |  lea RC, [KBASE+RC*8]
   |  jmp >1
   |
   |->vmeta_arith_nvo:
-  |.if DUALNUM
-  |  movzx RBd, PC_RB
-  |  movzx RCd, PC_RC
-  |.endif
   |->vmeta_arith_nv:
   |  lea TMPR, [KBASE+RC*8]
   |  lea RC, [BASE+RB*8]
@@ -1000,10 +982,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  jmp >2
   |
   |->vmeta_arith_vvo:
-  |.if DUALNUM
-  |  movzx RBd, PC_RB
-  |  movzx RCd, PC_RC
-  |.endif
   |->vmeta_arith_vv:
   |  lea RC, [BASE+RC*8]
   |1:
@@ -1319,11 +1297,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov CARG2, BASE			// Otherwise: CARG2 == BASE
   |.endif
   |  mov L:CARG1, L:RB
-  |.if DUALNUM
-  |  call extern lj_strfmt_number	// (lua_State *L, cTValue *o)
-  |.else
   |  call extern lj_strfmt_num		// (lua_State *L, lua_Number *np)
-  |.endif
   |  // GCstr returned in eax (RD).
   |  mov BASE, L:RB->base
   |  settp STR:RB, RD, LJ_TSTR
@@ -1394,24 +1368,13 @@ static void build_subroutines(BuildCtx *ctx)
   |.ffunc_2 ipairs_aux
   |  mov TAB:RB, [BASE]
   |  checktab TAB:RB, ->fff_fallback
-  |.if DUALNUM
-  |  mov RA, [BASE+8]
-  |  checkint RA, ->fff_fallback
-  |.else
   |  checknumtp [BASE+8], ->fff_fallback
   |  movsd xmm0, qword [BASE+8]
-  |.endif
   |  mov PC, [BASE-8]
-  |.if DUALNUM
-  |  add RAd, 1
-  |  setint ITYPE, RA
-  |  mov [BASE-16], ITYPE
-  |.else
   |  sseconst_1 xmm1, TMPR
   |  addsd xmm0, xmm1
   |  cvttsd2si RAd, xmm0
   |  movsd qword [BASE-16], xmm0
-  |.endif
   |  cmp RAd, TAB:RB->asize;  jae >2	// Not in array part?
   |  mov RD, TAB:RB->array
   |  lea RD, [RD+RA*8]
@@ -1456,12 +1419,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov PC, [BASE-8]
   |  mov [BASE-16], CFUNC:RD
   |  mov [BASE-8], TMPR
-  |.if DUALNUM
-  |  mov64 RD, ((uint64_t)LJ_TISNUM<<47)
-  |  mov [BASE], RD
-  |.else
   |  mov qword [BASE], 0
-  |.endif
   |  mov RDd, 1+3
   |  jmp ->fff_res
   |
@@ -1658,25 +1616,7 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |  .ffunc_1 math_abs
   |  mov RB, [BASE]
-  |.if DUALNUM
-  |  checkint RB, >3
-  |  cmp RBd, 0; jns ->fff_resi
-  |  neg RBd; js >2
-  |->fff_resbit:
-  |->fff_resi:
-  |  setint RB
-  |->fff_resRB:
-  |  mov PC, [BASE-8]
-  |  mov [BASE-16], RB
-  |  jmp ->fff_res1
-  |2:
-  |  mov64 RB, U64x(41e00000,00000000)  // 2^31.
-  |  jmp ->fff_resRB
-  |3:
-  |  ja ->fff_fallback
-  |.else
   |  checknum RB, ->fff_fallback
-  |.endif
   |  shl RB, 1
   |  shr RB, 1
   |  mov PC, [BASE-8]
@@ -1716,24 +1656,9 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |.macro math_round, func
   |  .ffunc math_ .. func
-  |.if DUALNUM
-  |  mov RB, [BASE]
-  |  checknumx RB, ->fff_resRB, je
-  |  ja ->fff_fallback
-  |.else
   |  checknumtp [BASE], ->fff_fallback
-  |.endif
   |  movsd xmm0, qword [BASE]
   |  call ->vm_ .. func .. _sse
-  |.if DUALNUM
-  |  cvttsd2si RBd, xmm0
-  |  cmp RBd, 0x80000000
-  |  jne ->fff_resi
-  |  cvtsi2sd xmm1, RBd
-  |  ucomisd xmm0, xmm1
-  |  jp ->fff_resxmm0
-  |  je ->fff_resi
-  |.endif
   |  jmp ->fff_resxmm0
   |.endmacro
   |
@@ -1803,13 +1728,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov RBd, TMP1d
   |  mov PC, [BASE-8]
   |  movsd qword [BASE-16], xmm0
-  |.if DUALNUM
-  |  setint RB
-  |  mov [BASE-8], RB
-  |.else
   |  cvtsi2sd xmm1, RBd
   |  movsd qword [BASE-8], xmm1
-  |.endif
   |  mov RDd, 1+2
   |  jmp ->fff_res
   |
@@ -1830,40 +1750,12 @@ static void build_subroutines(BuildCtx *ctx)
   |.macro math_minmax, name, cmovop, sseop
   |  .ffunc name
   |  mov RAd, 2
-  |.if DUALNUM
-  |  mov RB, [BASE]
-  |  checkint RB, >4
-  |1:  // Handle integers.
-  |  cmp RAd, RDd; jae ->fff_resRB
-  |  mov TMPR, [BASE+RA*8-8]
-  |  checkint TMPR, >3
-  |  cmp RBd, TMPRd
-  |  cmovop RB, TMPR
-  |  add RAd, 1
-  |  jmp <1
-  |3:
-  |  ja ->fff_fallback
-  |  // Convert intermediate result to number and continue below.
-  |  cvtsi2sd xmm0, RBd
-  |  jmp >6
-  |4:
-  |  ja ->fff_fallback
-  |.else
   |  checknumtp [BASE], ->fff_fallback
-  |.endif
   |
   |  movsd xmm0, qword [BASE]
   |5:  // Handle numbers or integers.
   |  cmp RAd, RDd; jae ->fff_resxmm0
-  |.if DUALNUM
-  |  mov RB, [BASE+RA*8-8]
-  |  checknumx RB, >6, jb
-  |  ja ->fff_fallback
-  |  cvtsi2sd xmm1, RBd
-  |  jmp >7
-  |.else
   |  checknumtp [BASE+RA*8-8], ->fff_fallback
-  |.endif
   |6:
   |  movsd xmm1, qword [BASE+RA*8-8]
   |7:
@@ -1885,22 +1777,13 @@ static void build_subroutines(BuildCtx *ctx)
   |  cmp dword STR:RB->len, 1
   |  jb ->fff_res0			// Return no results for empty string.
   |  movzx RBd, byte STR:RB[1]
-  |.if DUALNUM
-  |  jmp ->fff_resi
-  |.else
   |  cvtsi2sd xmm0, RBd; jmp ->fff_resxmm0
-  |.endif
   |
   |.ffunc string_char			// Only handle the 1-arg case here.
   |  ffgccheck
   |  cmp NARGS:RDd, 1+1;  jne ->fff_fallback	// *Exactly* 1 arg.
-  |.if DUALNUM
-  |  mov RB, [BASE]
-  |  checkint RB, ->fff_fallback
-  |.else
   |  checknumtp [BASE], ->fff_fallback
   |  cvttsd2si RBd, qword [BASE]
-  |.endif
   |  cmp RBd, 255;  ja ->fff_fallback
   |  mov TMP1d, RBd
   |  mov TMPRd, 1
@@ -1926,26 +1809,13 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov TMPRd, -1
   |  cmp NARGS:RDd, 1+2;  jb ->fff_fallback
   |  jna >1
-  |.if DUALNUM
-  |  mov TMPR, [BASE+16]
-  |  checkint TMPR, ->fff_fallback
-  |.else
   |  checknumtp [BASE+16], ->fff_fallback
   |  cvttsd2si TMPRd, qword [BASE+16]
-  |.endif
   |1:
   |  mov STR:RB, [BASE]
   |  checkstr STR:RB, ->fff_fallback
-  |.if DUALNUM
-  |  mov ITYPE, [BASE+8]
-  |  mov RAd, ITYPEd			// Must clear hiword for lea below.
-  |  sar ITYPE, 47
-  |  cmp ITYPEd, LJ_TISNUM
-  |  jne ->fff_fallback
-  |.else
   |  checknumtp [BASE+8], ->fff_fallback
   |  cvttsd2si RAd, qword [BASE+8]
-  |.endif
   |  mov RCd, STR:RB->len
   |  cmp RCd, TMPRd			// len < end? (unsigned compare)
   |  jb >5
@@ -2018,21 +1888,8 @@ static void build_subroutines(BuildCtx *ctx)
   |.if kind == 2
   |  sseconst_tobit xmm1, RB
   |.endif
-  |.if DUALNUM
-  |  mov RB, [BASE]
-  |  checkint RB, >1
-  |.if kind > 0
-  |  jmp >2
-  |.else
-  |  jmp ->fff_resbit
-  |.endif
-  |1:
-  |  ja ->fff_fallback
-  |  movd xmm0, RB
-  |.else
   |  checknumtp [BASE], ->fff_fallback
   |  movsd xmm0, qword [BASE]
-  |.endif
   |.if kind < 2
   |  sseconst_tobit xmm1, RB
   |.endif
@@ -2055,19 +1912,8 @@ static void build_subroutines(BuildCtx *ctx)
   |1:
   |  cmp RD, BASE
   |  jbe ->fff_resbit
-  |.if DUALNUM
-  |  mov RA, [RD]
-  |  checkint RA, >2
-  |  ins RBd, RAd
-  |  sub RD, 8
-  |  jmp <1
-  |2:
-  |  ja ->fff_fallback_bit_op
-  |  movd xmm0, RA
-  |.else
   |  checknumtp [RD], ->fff_fallback_bit_op
   |  movsd xmm0, qword [RD]
-  |.endif
   |  addsd xmm0, xmm1
   |  movd RAd, xmm0
   |  ins RBd, RAd
@@ -2085,32 +1931,21 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |.ffunc_bit bit_bnot, 1
   |  not RBd
-  |.if DUALNUM
-  |  jmp ->fff_resbit
-  |.else
   |->fff_resbit:
   |  cvtsi2sd xmm0, RBd
   |  jmp ->fff_resxmm0
-  |.endif
   |
   |->fff_fallback_bit_op:
   |  mov NARGS:RDd, TMPRd		// Restore for fallback
   |  jmp ->fff_fallback
   |
   |.macro .ffunc_bit_sh, name, ins
-  |.if DUALNUM
-  |  .ffunc_bit name, 1, .ffunc_2
-  |  // Note: no inline conversion from number for 2nd argument!
-  |  mov RA, [BASE+8]
-  |  checkint RA, ->fff_fallback
-  |.else
   |  .ffunc_nn name
   |  sseconst_tobit xmm2, RB
   |  addsd xmm0, xmm2
   |  addsd xmm1, xmm2
   |  movd RBd, xmm0
   |  movd RAd, xmm1
-  |.endif
   |  ins RBd, cl			// Assumes RA is ecx.
   |  jmp ->fff_resbit
   |.endmacro
@@ -2793,36 +2628,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov RD, RB
     |  sar ITYPE, 47
     |  sar RB, 47
-    |.if DUALNUM
-    |  cmp ITYPEd, LJ_TISNUM; jne >7
-    |  cmp RBd, LJ_TISNUM; jne >8
-    |  add PC, 4
-    |  cmp RAd, RDd
-    |  jmp_comp jge, jl, jg, jle, >9
-    |6:
-    |  movzx RDd, PC_RD
-    |  branchPC RD
-    |9:
-    |  ins_next
-    |
-    |7:  // RA is not an integer.
-    |  ja ->vmeta_comp
-    |  // RA is a number.
-    |  cmp RBd, LJ_TISNUM; jb >1; jne ->vmeta_comp
-    |  // RA is a number, RD is an integer.
-    |  cvtsi2sd xmm0, RDd
-    |  jmp >2
-    |
-    |8:  // RA is an integer, RD is not an integer.
-    |  ja ->vmeta_comp
-    |  // RA is an integer, RD is a number.
-    |  cvtsi2sd xmm1, RAd
-    |  movd xmm0, RD
-    |  jmp >3
-    |.else
     |  cmp ITYPEd, LJ_TISNUM; jae ->vmeta_comp
     |  cmp RBd, LJ_TISNUM; jae ->vmeta_comp
-    |.endif
     |1:
     |  movd xmm0, RD
     |2:
@@ -2832,16 +2639,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ucomisd xmm0, xmm1
     |  // Unordered: all of ZF CF PF set, ordered: PF clear.
     |  // To preserve NaN semantics GE/GT branch on unordered, but LT/LE don't.
-    |.if DUALNUM
-    |  jmp_comp jbe, ja, jb, jae, <9
-    |  jmp <6
-    |.else
     |  jmp_comp jbe, ja, jb, jae, >1
     |  movzx RDd, PC_RD
     |  branchPC RD
     |1:
     |  ins_next
-    |.endif
     break;
 
   case BC_ISEQV: case BC_ISNEV:
@@ -2854,40 +2656,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov RA, ITYPE
     |  sar RB, 47
     |  sar ITYPE, 47
-    |.if DUALNUM
-    |  cmp RBd, LJ_TISNUM; jne >7
-    |  cmp ITYPEd, LJ_TISNUM; jne >8
-    |  cmp RDd, RAd
-    if (vk) {
-      |  jne >9
-    } else {
-      |  je >9
-    }
-    |  movzx RDd, PC_RD
-    |  branchPC RD
-    |9:
-    |  ins_next
-    |
-    |7:  // RD is not an integer.
-    |  ja >5
-    |  // RD is a number.
-    |  movd xmm1, RD
-    |  cmp ITYPEd, LJ_TISNUM; jb >1; jne >5
-    |  // RD is a number, RA is an integer.
-    |  cvtsi2sd xmm0, RAd
-    |  jmp >2
-    |
-    |8:  // RD is an integer, RA is not an integer.
-    |  ja >5
-    |  // RD is an integer, RA is a number.
-    |  cvtsi2sd xmm1, RDd
-    |  jmp >1
-    |
-    |.else
     |  cmp RBd, LJ_TISNUM; jae >5
     |  cmp ITYPEd, LJ_TISNUM; jae >5
     |  movd xmm1, RD
-    |.endif
     |1:
     |  movd xmm0, RA
     |2:
@@ -2919,12 +2690,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
       |  branchPC RD
       |1:				// EQ: Fallthrough to next instruction.
     }
-    if (LJ_DUALNUM && (op == BC_ISEQV || op == BC_ISNEV ||
-		       op == BC_ISEQN || op == BC_ISNEN)) {
-      |  jmp <9
-    } else {
-      |  ins_next
-    }
+    |  ins_next
     |
     if (op == BC_ISEQV || op == BC_ISNEV) {
       |5:  // Either or both types are not numbers.
@@ -2957,11 +2723,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
       |.if FFI
       |3:
       |  cmp ITYPEd, LJ_TCDATA
-      if (LJ_DUALNUM && vk) {
-	|  jne <9
-      } else {
-	|  jne <2
-      }
+      |  jne <2
       |  jmp ->vmeta_equal_cd
       |.endif
     }
@@ -2985,42 +2747,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_AD	// RA = src, RD = num const, JMP with RD = target
     |  mov RB, [BASE+RA*8]
     |  add PC, 4
-    |.if DUALNUM
-    |  checkint RB, >7
-    |  mov RD, [KBASE+RD*8]
-    |  checkint RD, >8
-    |  cmp RBd, RDd
-    if (vk) {
-      |  jne >9
-    } else {
-      |  je >9
-    }
-    |  movzx RDd, PC_RD
-    |  branchPC RD
-    |9:
-    |  ins_next
-    |
-    |7:  // RA is not an integer.
-    |  ja >3
-    |  // RA is a number.
-    |  mov RD, [KBASE+RD*8]
-    |  checkint RD, >1
-    |  // RA is a number, RD is an integer.
-    |  cvtsi2sd xmm0, RDd
-    |  jmp >2
-    |
-    |8:  // RA is an integer, RD is a number.
-    |  cvtsi2sd xmm0, RBd
-    |  movd xmm1, RD
-    |  ucomisd xmm0, xmm1
-    |  jmp >4
-    |1:
-    |  movd xmm0, RD
-    |.else
     |  checknum RB, >3
     |1:
     |  movsd xmm0, qword [KBASE+RD*8]
-    |.endif
     |2:
     |  ucomisd xmm0, qword [BASE+RA*8]
     |4:
@@ -3114,46 +2843,20 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_UNM:
     |  ins_AD	// RA = dst, RD = src
     |  mov RB, [BASE+RD*8]
-    |.if DUALNUM
-    |  checkint RB, >5
-    |  neg RBd
-    |  jo >4
-    |  setint RB
-    |9:
-    |  mov [BASE+RA*8], RB
-    |  ins_next
-    |4:
-    |  mov64 RB, U64x(41e00000,00000000)  // 2^31.
-    |  jmp <9
-    |5:
-    |  ja ->vmeta_unm
-    |.else
     |  checknum RB, ->vmeta_unm
-    |.endif
     |  mov64 RD, U64x(80000000,00000000)
     |  xor RB, RD
-    |.if DUALNUM
-    |  jmp <9
-    |.else
     |  mov [BASE+RA*8], RB
     |  ins_next
-    |.endif
     break;
   case BC_LEN:
     |  ins_AD	// RA = dst, RD = src
     |  mov RD, [BASE+RD*8]
     |  checkstr RD, >2
-    |.if DUALNUM
-    |  mov RDd, dword STR:RD->len
-    |1:
-    |  setint RD
-    |  mov [BASE+RA*8], RD
-    |.else
     |  xorps xmm0, xmm0
     |  cvtsi2sd xmm0, dword STR:RD->len
     |1:
     |  movsd qword [BASE+RA*8], xmm0
-    |.endif
     |  ins_next
     |2:
     |  cmp ITYPEd, LJ_TTAB; jne ->vmeta_len
@@ -3168,11 +2871,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov RB, BASE			// Save BASE.
     |  call extern lj_tab_len		// (GCtab *t)
     |  // Length of table returned in eax (RD).
-    |.if DUALNUM
-    |  // Nothing to do.
-    |.else
     |  cvtsi2sd xmm0, RDd
-    |.endif
     |  mov BASE, RB			// Restore BASE.
     |  movzx RAd, PC_RA
     |  jmp <1
@@ -3192,17 +2891,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     ||switch (vk) {
     ||case 0:
     |   checknumtp [BASE+RB*8], ->vmeta_arith_vn
-    |   .if DUALNUM
-    |     checknumtp [KBASE+RC*8], ->vmeta_arith_vn
-    |   .endif
     |   movsd xmm0, qword [BASE+RB*8]
     |   sseins ssereg, qword [KBASE+RC*8]
     ||  break;
     ||case 1:
     |   checknumtp [BASE+RB*8], ->vmeta_arith_nv
-    |   .if DUALNUM
-    |     checknumtp [KBASE+RC*8], ->vmeta_arith_nv
-    |   .endif
     |   movsd xmm0, qword [KBASE+RC*8]
     |   sseins ssereg, qword [BASE+RB*8]
     ||  break;
@@ -3262,11 +2955,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endmacro
     |
     |.macro ins_arith, intins, sseins
-    |.if DUALNUM
-    |  ins_arithdn intins
-    |.else
     |  ins_arith, sseins
-    |.endif
     |.endmacro
 
     |  // RA = dst, RB = src1 or num const, RC = src2 or num const
@@ -3345,15 +3034,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
   case BC_KSHORT:
     |  ins_AD	// RA = dst, RD = signed int16 literal
-    |.if DUALNUM
-    |  movsx RDd, RDW
-    |  setint RD
-    |  mov [BASE+RA*8], RD
-    |.else
     |  movsx RDd, RDW			// Sign-extend literal.
     |  cvtsi2sd xmm0, RDd
     |  movsd qword [BASE+RA*8], xmm0
-    |.endif
     |  ins_next
     break;
   case BC_KNUM:
@@ -3602,9 +3285,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  checktab TAB:RB, ->vmeta_tgetv
     |
     |  // Integer key?
-    |.if DUALNUM
-    |  checkint RC, >5
-    |.else
     |  // Convert number to int and back and compare.
     |  checknum RC, >5
     |  movd xmm0, RC
@@ -3612,7 +3292,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cvtsi2sd xmm1, RCd
     |  ucomisd xmm0, xmm1
     |  jne ->vmeta_tgetv		// Generic numeric key? Use fallback.
-    |.endif
     |  cmp RCd, TAB:RB->asize		// Takes care of unordered, too.
     |  jae ->vmeta_tgetv		// Not in array part? Use fallback.
     |  shl RCd, 3
@@ -3704,11 +3383,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_ABC	// RA = dst, RB = table, RC = key
     |  mov TAB:RB, [BASE+RB*8]
     |  cleartp TAB:RB
-    |.if DUALNUM
-    |  mov RCd, dword [BASE+RC*8]
-    |.else
     |  cvttsd2si RCd, qword [BASE+RC*8]
-    |.endif
     |  cmp RCd, TAB:RB->asize
     |  jae ->vmeta_tgetr		// Not in array part? Use fallback.
     |  shl RCd, 3
@@ -3728,9 +3403,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  checktab TAB:RB, ->vmeta_tsetv
     |
     |  // Integer key?
-    |.if DUALNUM
-    |  checkint RC, >5
-    |.else
     |  // Convert number to int and back and compare.
     |  checknum RC, >5
     |  movd xmm0, RC
@@ -3738,7 +3410,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cvtsi2sd xmm1, RCd
     |  ucomisd xmm0, xmm1
     |  jne ->vmeta_tsetv		// Generic numeric key? Use fallback.
-    |.endif
     |  cmp RCd, TAB:RB->asize		// Takes care of unordered, too.
     |  jae ->vmeta_tsetv
     |  shl RCd, 3
@@ -3870,11 +3541,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_ABC	// RA = src, RB = table, RC = key
     |  mov TAB:RB, [BASE+RB*8]
     |  cleartp TAB:RB
-    |.if DUALNUM
-    |  mov RC, [BASE+RC*8]
-    |.else
     |  cvttsd2si RCd, qword [BASE+RC*8]
-    |.endif
     |  test byte TAB:RB->marked, LJ_GC_BLACK	// isblack(table)
     |  jnz >7
     |2:
@@ -4043,19 +3710,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |1:  // Traverse array part.
     |  cmp RCd, TMPRd; jae >5		// Index points after array part?
     |  cmp aword [ITYPE+RC*8], LJ_TNIL; je >4
-    |.if not DUALNUM
     |  cvtsi2sd xmm0, RCd
-    |.endif
     |  // Copy array slot to returned value.
     |  mov RB, [ITYPE+RC*8]
     |  mov [BASE+RA*8+8], RB
     |  // Return array index as a numeric key.
-    |.if DUALNUM
-    |  setint ITYPE, RC
-    |  mov [BASE+RA*8], ITYPE
-    |.else
     |  movsd qword [BASE+RA*8], xmm0
-    |.endif
     |  add RCd, 1
     |  mov [BASE+RA*8-8], RCd		// Update control var.
     |2:
@@ -4275,91 +3935,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     vk = (op == BC_IFORL || op == BC_JFORL);
     |  ins_AJ	// RA = base, RD = target (after end of loop or start of loop)
     |  lea RA, [BASE+RA*8]
-    if (LJ_DUALNUM) {
-      |  mov RB, FOR_IDX
-      |  checkint RB, >9
-      |  mov TMPR, FOR_STOP
-      if (!vk) {
-	|  checkint TMPR, ->vmeta_for
-	|  mov ITYPE, FOR_STEP
-	|  test ITYPEd, ITYPEd; js >5
-	|  sar ITYPE, 47;
-	|  cmp ITYPEd, LJ_TISNUM; jne ->vmeta_for
-      } else {
 #ifdef LUA_USE_ASSERT
-	|  checkinttp FOR_STOP, ->assert_bad_for_arg_type
-	|  checkinttp FOR_STEP, ->assert_bad_for_arg_type
+    |  checknumtp FOR_STOP, ->assert_bad_for_arg_type
+    |  checknumtp FOR_STEP, ->assert_bad_for_arg_type
 #endif
-	|  mov ITYPE, FOR_STEP
-	|  test ITYPEd, ITYPEd; js >5
-	|  add RBd, ITYPEd; jo >1
-	|  setint RB
-	|  mov FOR_IDX, RB
-      }
-      |  cmp RBd, TMPRd
-      |  mov FOR_EXT, RB
-      if (op == BC_FORI) {
-	|  jle >7
-	|1:
-	|6:
-	|  branchPC RD
-      } else if (op == BC_JFORI) {
-	|  branchPC RD
-	|  movzx RDd, PC_RD
-	|  jle =>BC_JLOOP
-	|1:
-	|6:
-      } else if (op == BC_IFORL) {
-	|  jg >7
-	|6:
-	|  branchPC RD
-	|1:
-      } else {
-	|  jle =>BC_JLOOP
-	|1:
-	|6:
-      }
-      |7:
-      |  ins_next
-      |
-      |5:  // Invert check for negative step.
-      if (!vk) {
-	|  sar ITYPE, 47;
-	|  cmp ITYPEd, LJ_TISNUM; jne ->vmeta_for
-      } else {
-	|  add RBd, ITYPEd; jo <1
-	|  setint RB
-	|  mov FOR_IDX, RB
-      }
-      |  cmp RBd, TMPRd
-      |  mov FOR_EXT, RB
-      if (op == BC_FORI) {
-	|  jge <7
-      } else if (op == BC_JFORI) {
-	|  branchPC RD
-	|  movzx RDd, PC_RD
-	|  jge =>BC_JLOOP
-      } else if (op == BC_IFORL) {
-	|  jl <7
-      } else {
-	|  jge =>BC_JLOOP
-      }
-      |  jmp <6
-      |9:  // Fallback to FP variant.
-      if (!vk) {
-	|  jae ->vmeta_for
-      }
-    } else if (!vk) {
-      |  checknumtp FOR_IDX, ->vmeta_for
-    }
-    if (!vk) {
-      |  checknumtp FOR_STOP, ->vmeta_for
-    } else {
-#ifdef LUA_USE_ASSERT
-      |  checknumtp FOR_STOP, ->assert_bad_for_arg_type
-      |  checknumtp FOR_STEP, ->assert_bad_for_arg_type
-#endif
-    }
     |  mov RB, FOR_STEP
     if (!vk) {
       |  checknum RB, ->vmeta_for
@@ -4377,32 +3956,20 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |1:
     |  movsd qword FOR_EXT, xmm0
     if (op == BC_FORI) {
-      |.if DUALNUM
-      |  jnb <7
-      |.else
       |  jnb >2
       |  branchPC RD
-      |.endif
     } else if (op == BC_JFORI) {
       |  branchPC RD
       |  movzx RDd, PC_RD
       |  jnb =>BC_JLOOP
     } else if (op == BC_IFORL) {
-      |.if DUALNUM
-      |  jb <7
-      |.else
       |  jb >2
       |  branchPC RD
-      |.endif
     } else {
       |  jnb =>BC_JLOOP
     }
-    |.if DUALNUM
-    |  jmp <6
-    |.else
     |2:
     |  ins_next
-    |.endif
     |
     |3:  // Invert comparison if step is negative.
     |  ucomisd xmm0, xmm1


### PR DESCRIPTION
DUALNUM mode is a complex optional feature, disabled by default on
x86-64, that allows numbers to be stored on the heap either as doubles
(the usual) or as integers (the extension.)

This requires a _LOT_ of ifdef-style conditional logic throughout the
VM and runtime system. My tests have never found a verifiable benefit
to the dual number mode and since it is already disabled by default on
x86-64 I have simply removed it.

This change is a bit scary because it is large and I have mostly made
it manually. The conditional uses of DUALNUM were not ones that I
could remove automatically with 'unifdef'. I have surely made a
mistake in here somewhere and that will surely bit somebody on the
backside one day... Sorry in advance, but meanwhile, onward!