### PR TITLE
Remove LJ_LIKELY() and LJ_UNLIKELY()

### DIFF
--- a/src/lib_ffi.c
+++ b/src/lib_ffi.c
@@ -615,7 +615,7 @@ LJLIB_CF(ffi_sizeof)	LJLIB_REC(ffi_xof FF_ffi_sizeof)
   CTState *cts = ctype_cts(L);
   CTypeID id = ffi_checkctype(L, cts, NULL);
   CTSize sz;
-  if (LJ_UNLIKELY(tviscdata(L->base) && cdataisv(cdataV(L->base)))) {
+  if (tviscdata(L->base) && cdataisv(cdataV(L->base))) {
     sz = cdatavlen(cdataV(L->base));
   } else {
     CType *ct = lj_ctype_rawref(cts, id);
@@ -623,7 +623,7 @@ LJLIB_CF(ffi_sizeof)	LJLIB_REC(ffi_xof FF_ffi_sizeof)
       sz = lj_ctype_vlsize(cts, ct, (CTSize)ffi_checkint(L, 2));
     else
       sz = ctype_hassize(ct->info) ? ct->size : CTSIZE_INVALID;
-    if (LJ_UNLIKELY(sz == CTSIZE_INVALID)) {
+    if (sz == CTSIZE_INVALID) {
       setnilV(L->top-1);
       return 1;
     }

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -354,7 +354,7 @@ static void trace_start(jit_State *J)
 
   /* Get a new trace number. */
   traceno = trace_findfree(J);
-  if (LJ_UNLIKELY(traceno == 0)) {  /* No free trace? */
+  if (traceno == 0) {  /* No free trace? */
     lua_assert((J2G(J)->hookmask & HOOK_GC) == 0);
     lj_trace_flushall(J->L);
     J->state = LJ_TRACE_IDLE;  /* Silently ignored. */
@@ -518,7 +518,7 @@ static int trace_abort(jit_State *J)
 /* Perform pending re-patch of a bytecode instruction. */
 static LJ_AINLINE void trace_pendpatch(jit_State *J, int force)
 {
-  if (LJ_UNLIKELY(J->patchpc)) {
+  if (J->patchpc) {
     if (force || J->bcskip == 0) {
       *J->patchpc = J->patchins;
       J->patchpc = NULL;


### PR DESCRIPTION
I find that these declarations clutter the code, and I consider them
to be optimizations that should only be used when and where they have
a beneficial effect. I also suspect the benefit to be rare on
supported RaptorJIT platforms because:

- Intel CPUs do excellent dynamic branch prediction;
- Declarations don't affect the interpreter (asm code);
- Declarations don't affect the JIT (generated code)

So it's only the runtime system e.g. garbage collector.

Have to check for a performance regression before merging this change.

(I am looking for the LKML thread where Ingo Molnar benchmarked the
kernel and found that the likely/unlikely annotations were actually
_reducing_ performance in practice -- but I can't find it so maybe I
dreamed it.)

NOTE: There is some risk that I introduced a bug in this change. I made the changes with help of an Emacs macro that does a reasonable job of removing the right balanced parenthesis but could potentially have made semantic changes due to operator precedence or pseudo-parser-kludgery. Quick review would be much appreciated to save getting bitten later!