### PR TITLE
Fix IR_KKPTR case of #47

### DIFF
--- a/src/lj_asm_x86.h
+++ b/src/lj_asm_x86.h
@@ -1373,7 +1373,7 @@ static void asm_cnew(ASMState *as, IRIns *ir)
     Reg r64 = sz == 8 ? REX_64 : 0;
     if (irref_isk(ir->op2)) {
       IRIns *irk = IR(ir->op2);
-      uint64_t k = (irk->o == IR_KINT64 || irk->o == IR_KPTR || irk->o == IR_KPTR)
+      uint64_t k = (irk->o == IR_KINT64 || irk->o == IR_KPTR || irk->o == IR_KKPTR)
                    ? ir_k64(irk)->u64 : (uint64_t)(uint32_t)irk->i;
       if (sz == 4 || checki32((int64_t)k)) {
 	emit_i32(as, (int32_t)k);


### PR DESCRIPTION
Fix typo `s/IR_KPTR/IR_KKPTR/` bug in b1cfd2730e42d8a0b8d5f76f0c05dac948925dec affecting constant pointers to constant values.

Thanks @jaens for catching this at https://github.com/raptorjit/raptorjit/pull/47#commitcomment-21392114.