### PR TITLE
Compile with -Weverything (all warnings)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ CC= $(DEFAULT_CC)
 # to slow down the C part by not omitting it. Debugging, tracebacks and
 # unwinding are not affected -- the assembler part has frame unwind
 # information and GCC emits it where needed (x64) or with -g (see CCDEBUG).
-CCOPT= -O2 -fomit-frame-pointer
+CCOPT= -O2 -fomit-frame-pointer -Werror
 # Use this if you want to generate a smaller binary (but it's slower):
 #CCOPT= -Os -fomit-frame-pointer
 # Note: it's no longer recommended to use -O3 with GCC 4.x.

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ CC= $(DEFAULT_CC)
 # to slow down the C part by not omitting it. Debugging, tracebacks and
 # unwinding are not affected -- the assembler part has frame unwind
 # information and GCC emits it where needed (x64) or with -g (see CCDEBUG).
-CCOPT= -O2 -fomit-frame-pointer -Werror
+CCOPT= -O2 -fomit-frame-pointer -Werror -Weverything
 # Use this if you want to generate a smaller binary (but it's slower):
 #CCOPT= -Os -fomit-frame-pointer
 # Note: it's no longer recommended to use -O3 with GCC 4.x.


### PR DESCRIPTION
Compile with the most pedantic C compiler warnings available. This is combined with `-Werror` (#50) so that CI will fail any code that produces a warning from the C compiler.

The premise is that we need all of the help we can get from the compiler because our C code is extremely complex and even tiny bugs can easily cost people days or weeks of productivity.

Note: RaptorJIT is using `nix` to explicitly manage the C compiler dependency and so the warnings will be generated from the one specific compiler that we support (currently clang 3.8.)