### PR TITLE
Generate separate DWARF debug info

### DIFF
--- a/raptorjit.nix
+++ b/raptorjit.nix
@@ -9,10 +9,14 @@ mkDerivation rec {
   name = "raptorjit-${version}";
   inherit version;
   src = source;
-  buildInputs = [ luajit ];  # LuaJIT to bootstrap DynASM
+  buildInputs = [
+      luajit                # LuaJIT to bootstrap DynASM
+      gcc6                  # GCC for generating DWARF info
+    ];
+  dontStrip = true;         # No extra stripping (preserve debug info)
   installPhase = ''
-    mkdir -p $out/bin
-    cp src/luajit $out/bin/raptorjit
+    install -D src/luajit $out/bin/raptorjit
+    install -D src/lj_dwarf.dwo $out/lib/raptorjit.dwo
   '';
 
   enableParallelBuilding = true;  # Do 'make -j'

--- a/src/Makefile
+++ b/src/Makefile
@@ -475,6 +475,8 @@ LJCORE_O= lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o lj_buf.o \
 	  lj_lib.o lj_alloc.o lib_aux.o \
 	  $(LJLIB_O) lib_init.o
 
+DWARF_DWO= lj_dwarf.dwo
+
 LJVMCORE_O= $(LJVM_O) $(LJCORE_O)
 LJVMCORE_DYNO= $(LJVMCORE_O:.o=_dyn.o)
 
@@ -566,7 +568,7 @@ E= @echo
 # Make targets.
 ##############################################################################
 
-default all:	$(TARGET_T)
+default all:	$(TARGET_T) $(DWARF_DWO)
 
 clean:
 	$(HOST_RM) $(ALL_RM)
@@ -654,6 +656,11 @@ $(LUAJIT_O):
 $(HOST_O): %.o: %.c
 	$(E) "HOSTCC    $@"
 	$(Q)$(HOST_CC) $(HOST_ACFLAGS) -c -o $@ $<
+
+$(DWARF_DWO): %.dwo: %.c
+	$(E) "CC(debug) $@"
+#       GCC because clang does not seem to produce decent debug info (?)
+	$(Q)gcc -g3 -gdwarf-4 -fno-eliminate-unused-debug-types -gsplit-dwarf -c $<
 
 include Makefile.dep
 

--- a/src/lj_dwarf.c
+++ b/src/lj_dwarf.c
@@ -1,0 +1,24 @@
+/*
+** Compilation unit for DWARF debug information.
+*/
+
+#include "lj_obj.h"
+#include "lj_gc.h"
+#include "lj_err.h"
+#include "lj_debug.h"
+#include "lj_str.h"
+#include "lj_frame.h"
+#include "lj_state.h"
+#include "lj_bc.h"
+#include "lj_ir.h"
+#include "lj_jit.h"
+#include "lj_iropt.h"
+#include "lj_mcode.h"
+#include "lj_trace.h"
+#include "lj_snap.h"
+#include "lj_gdbjit.h"
+#include "lj_record.h"
+#include "lj_asm.h"
+#include "lj_dispatch.h"
+#include "lj_vm.h"
+#include "lj_target.h"


### PR DESCRIPTION
The build now produces a ".dwo" file containing DWARF debug information. This contains a binary encoding of internal information about RaptorJIT e.g. the layout of all its internal data structures.

The DWARF information is for use by debugging tools that need to understand JIT internals. In particular it will be necessary for decoding the internal binary data structures in the auditlog (#63).

The DWARF file is currently generated with gcc. I would prefer to use clang, for the sake of consistency with the rest of the build, but I seem to get _much_ more debug information from gcc so I stick with that for now.

The nix build expression outputs the debug information as
`lib/raptorjit.dwo`.

The debug information can be pretty-printed with a tool like `objdump` or `llvm-dwarfdump`. For example, here is the debug information about the `enum` that defines the IR instruction numbers:

```
 <1><253c>: Abbrev Number: 35 (DW_TAG_enumeration_type)
    <253d>   DW_AT_byte_size   : 4
    <253e>   DW_AT_type        : <0x77>
    <2542>   DW_AT_decl_file   : 26
    <2543>   DW_AT_decl_line   : 315
    <2545>   DW_AT_sibling     : <0x25d5>
 <2><2549>: Abbrev Number: 36 (DW_TAG_enumerator)
    <254a>   DW_AT_name        : (indexed string: 0xb75): IRT_NIL
    <254c>   DW_AT_const_value : 0
 <2><254d>: Abbrev Number: 36 (DW_TAG_enumerator)
    <254e>   DW_AT_name        : (indexed string: 0x593): IRT_FALSE
    <2550>   DW_AT_const_value : 1
 <2><2551>: Abbrev Number: 36 (DW_TAG_enumerator)
    <2552>   DW_AT_name        : (indexed string: 0x37): IRT_TRUE
    <2553>   DW_AT_const_value : 2
 <2><2554>: Abbrev Number: 36 (DW_TAG_enumerator)
    <2555>   DW_AT_name        : (indexed string: 0x85f): IRT_LIGHTUD
    <2557>   DW_AT_const_value : 3
 <2><2558>: Abbrev Number: 36 (DW_TAG_enumerator)
    <2559>   DW_AT_name        : (indexed string: 0x908): IRT_STR
    <255b>   DW_AT_const_value : 4
 <2><255c>: Abbrev Number: 36 (DW_TAG_enumerator)
    <255d>   DW_AT_name        : (indexed string: 0xa4a): IRT_P32
    <255f>   DW_AT_const_value : 5
 <2><2560>: Abbrev Number: 36 (DW_TAG_enumerator)
    <2561>   DW_AT_name        : (indexed string: 0x393): IRT_THREAD
    <2563>   DW_AT_const_value : 6
 <2><2564>: Abbrev Number: 36 (DW_TAG_enumerator)
    <2565>   DW_AT_name        : (indexed string: 0xb52): IRT_PROTO
    <2567>   DW_AT_const_value : 7
```
