### PR TITLE
vmprofile: Extend Lua API and add test cases

### DIFF
--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -204,16 +204,42 @@ LJLIB_CF(jit_opt_start)
 
 #define LJLIB_MODULE_jit_vmprofile
 
+LJLIB_CF(jit_vmprofile_open)
+{
+  if (L->base < L->top && tvisstr(L->base)) {
+    return luaJIT_vmprofile_open(L, strdata(lj_lib_checkstr(L, 1)));
+  } else {
+    lj_err_argtype(L, 1, "filename");
+    return 0;
+  }
+}
+
+LJLIB_CF(jit_vmprofile_close)
+{
+  if (L->base < L->top && tvislightud(L->base)) {
+    return luaJIT_vmprofile_close(L, lightudV(L->base));
+  } else {
+    lj_err_argtype(L, 1, "vmprofile");
+  }
+}
+
+LJLIB_CF(jit_vmprofile_select)
+{
+  if (L->base < L->top && tvislightud(L->base)) {
+    return luaJIT_vmprofile_select(L, lightudV(L->base));
+  } else {
+    lj_err_argtype(L, 1, "vmprofile");
+  }
+}
+
 LJLIB_CF(jit_vmprofile_start)
 {
-  luaJIT_vmprofile_start(L);
-  return 0;
+  return luaJIT_vmprofile_start(L);
 }
 
 LJLIB_CF(jit_vmprofile_stop)
 {
-  luaJIT_vmprofile_stop(L);
-  return 0;
+  return luaJIT_vmprofile_stop(L);
 }
 
 #include "lj_libdef.h"
@@ -233,7 +259,6 @@ JIT_PARAMDEF(JIT_PARAMINIT)
 #undef JIT_PARAMINIT
   0
 };
-
 
 /* Arch-dependent CPU detection. */
 static uint32_t jit_cpudetect(lua_State *L)

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -65,8 +65,11 @@ enum {
 LUA_API int luaJIT_setmode(lua_State *L, int idx, int mode);
 
 /* VM profiling API. */
-LUA_API void luaJIT_vmprofile_start(lua_State *L);
-LUA_API void luaJIT_vmprofile_stop(lua_State *L);
+LUA_API int luaJIT_vmprofile_start(lua_State *L);
+LUA_API int luaJIT_vmprofile_open(lua_State *L, const char *str);
+LUA_API int luaJIT_vmprofile_select(lua_State *L, void *ud);
+LUA_API int luaJIT_vmprofile_close(lua_State *L, void *ud);
+LUA_API int luaJIT_vmprofile_stop(lua_State *L);
 
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);

--- a/testsuite/test/index
+++ b/testsuite/test/index
@@ -4,3 +4,4 @@ bc +luajit>=2
 computations.lua
 trace +jit
 opt +jit
+raptorjit

--- a/testsuite/test/raptorjit/index
+++ b/testsuite/test/raptorjit/index
@@ -1,0 +1,1 @@
+vmprofile.lua

--- a/testsuite/test/raptorjit/vmprofile.lua
+++ b/testsuite/test/raptorjit/vmprofile.lua
@@ -1,0 +1,34 @@
+local vmprofile = require("jit.vmprofile")
+
+do --- vmprofile start and stop
+   vmprofile.start()
+   vmprofile.stop()
+end
+
+
+do --- vmprofile multiple starts
+   for i = 1, 1000 do vmprofile.start() end
+   vmprofile.stop()
+end
+
+do --- vmprofile multiple profiles
+   vmprofile.start()
+   local a = vmprofile.open("a.vmprofile")
+   local b = vmprofile.open("b.vmprofile")
+   vmprofile.select(a)
+   for i = 1, 1e8 do end
+   vmprofile.select(b)
+   for i = 1, 1e8 do end
+   vmprofile.select(a)
+   for i = 1, 1e8 do end
+   vmprofile.stop()
+   vmprofile.close(a)
+   vmprofile.close(b)
+   -- simple sanity check that the profiles have different contents.
+   -- e.g. to make sure there was at least one sample taken somewhere.
+   assert(io.open("a.vmprofile", "r"):read("*a") ~=
+             io.open("b.vmprofile", "r"):read("*a"),
+          "check that profiles have different contents")
+   os.remove("a.vmprofile")
+   os.remove("b.vmprofile")
+end


### PR DESCRIPTION
Extend the "Lua C API" for vmprofile to support allocating multiple
profiles and switching between them. This makes it easier to use.

Previously the expectation was that this functionality would be
implemented in Lua code using ljsyscall to allocate file-backed shared
memory for profiles and then the FFI to switch between them. (This is
still possible, too, and it works the same as it did before.)

Added test coverage to the test suite.