### PR TITLE
GCtrace: Record origin of trace (parent & exitno)

### DIFF
--- a/check-generated-code.nix
+++ b/check-generated-code.nix
@@ -11,8 +11,10 @@ overrideDerivation raptorjit (as:
   {
     checkPhase = ''
       for f in ${generatedFiles}; do
+        echo "checking $f.."
         diff -u src/reusevm/$f src/$f
       done
+      echo "all files ok"
     '';
     doCheck = true;
   })

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -199,6 +199,8 @@ typedef struct GCtrace {
   TraceNo1 root;	/* Root trace of side trace (or 0 for root traces). */
   TraceNo1 nextroot;	/* Next root trace for same prototype. */
   TraceNo1 nextside;	/* Next side trace of same root trace. */
+  TraceNo1 parent;      /* Parent of this trace (or 0 for root traces). */
+  ExitNo exitno;        /* Exit number in parent (valid for side-traces only). */
   uint8_t sinktags;	/* Trace has SINK tags. */
   uint8_t unused1;
 } GCtrace;

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -109,6 +109,8 @@ static void trace_save(jit_State *J, GCtrace *T)
   size_t szins = (J->cur.nins-J->cur.nk)*sizeof(IRIns);
   char *p = (char *)T + sztr;
   memcpy(T, &J->cur, sizeof(GCtrace));
+  T->parent = J->parent;
+  T->exitno = J->exitno;
   setgcrefr(T->nextgc, J2G(J)->gc.root);
   setgcrefp(J2G(J)->gc.root, T);
   newwhite(J2G(J), T);


### PR DESCRIPTION
For debugging purposes it is very useful to be able to refer to the origin of a trace (parent/exit) and so this change stores that information persistently in `GCtrace` instead of only ephemerally in `jit_State`.

These fields are now duplicated in `jit_State` (valid while recording) and `GCtrace` (valid after recording.) This duplication could be avoided by putting them only in `GCtrace` and accessing them via `J->cur` but this would be a more noisy change since the existing fields are accessed from many places including DynASM macros.