### PR TITLE
lj_trace.c: Make trace numbers unique (stop reusing them)

### DIFF
--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -72,7 +72,7 @@ static TraceNo trace_findfree(jit_State *J)
   lj_mem_growvec(J->L, J->trace, J->sizetrace, lim, GCRef);
   for (; osz < J->sizetrace; osz++)
     setgcrefnull(J->trace[osz]);
-  return J->freetrace;
+  return J->freetrace++;
 }
 
 #define TRACE_APPENDVEC(field, szfield, tp) \
@@ -129,8 +129,6 @@ void lj_trace_free(global_State *g, GCtrace *T)
   jit_State *J = G2J(g);
   if (T->traceno) {
     lj_gdbjit_deltrace(J, T);
-    if (T->traceno < J->freetrace)
-      J->freetrace = T->traceno;
     setgcrefnull(J->trace[T->traceno]);
   }
   lj_mem_free(g, T,
@@ -250,7 +248,6 @@ int lj_trace_flushall(lua_State *L)
     }
   }
   J->cur.traceno = 0;
-  J->freetrace = 0;
   /* Clear penalty cache. */
   memset(J->penalty, 0, sizeof(J->penalty));
   /* Free the whole machine code and invalidate all exit stub groups. */


### PR DESCRIPTION
Make JIT trace numbers unique for completed traces. This way a trace
number is an unambiguous way to refer to a GCtrace object even across
flushes over the JIT.

The immediate motivation is to make the vmprofile data valid across
JIT flushes. It is counting samples by trace number and so when trace
numbers are reused then multiple traces can "collide" on the same
profiler counter.