### PR TITLE
Makefile: Added reusevm target at top-level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ default all $(INSTALL_DEP):
 	$(MAKE) -C src
 	@echo "==== Successfully built RaptorJIT $(VERSION) ===="
 
+reusevm:
+	$(MAKE) -C src reusevm
+
 install: $(INSTALL_DEP)
 	@echo "==== Installing RaptorJIT $(VERSION) to $(PREFIX) ===="
 	$(MKDIR) $(INSTALL_DIRS)


### PR DESCRIPTION
This makes the build work like it says in the README. (Otherwise you need to `cd` into `src/` to run `make reusevm`.)