### PR TITLE
x64/LJ_GC64: Fix asm_fuseloadk64()

### DIFF
--- a/src/lj_asm_x86.h
+++ b/src/lj_asm_x86.h
@@ -344,6 +344,7 @@ static Reg asm_fuseloadk64(ASMState *as, IRIns *ir)
       ir->i = (int32_t)(as->mctop - as->mcbot);
       as->mcbot += 8;
       as->mclim = as->mcbot + MCLIM_REDZONE;
+      lj_mcode_commitbot(as->J, as->mcbot);
     }
     as->mrm.ofs = (int32_t)mcpofs(as, as->mctop - ir->i);
     as->mrm.base = RID_RIP;


### PR DESCRIPTION
https://github.com/LuaJIT/LuaJIT/commit/78f5f1ce fixed emit_loadk64, but
overlooked asm_fuseloadk64.

Contributed by Peter Cawley.