### PR TITLE
GCtrace: Make it possible to map between IR and mcode insns

### DIFF
--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -192,6 +192,7 @@ typedef struct GCtrace {
   MSize szmcode;	/* Size of machine code. */
   MCode *mcode;		/* Start of machine code. */
   MSize mcloop;		/* Offset of loop start in machine code. */
+  uint16_t *szirmcode;  /* Bytes of mcode for each IR instruction (array.) */
   uint16_t nchild;	/* Number of child traces (root trace only). */
   uint16_t spadjust;	/* Stack pointer adjustment (offset in bytes). */
   TraceNo1 traceno;	/* Trace number. */


### PR DESCRIPTION
Add a `szirmcode` array to GCtrace that keeps track of how many bytes of machine code were assembled for each IR instruction.

This allows us to construct an association between IR code and mcode, either to see the mcode that was assembled for a given IR instruction, or to map a machine code instruction back to the relevant IR instruction.

Resolves the desire to be able to relate IR code and mcode expressed over at https://github.com/raptorjit/raptorjit/pull/63#issuecomment-309700685. cc @javierguerragiraldez.