### PR TITLE
JIT heuristic updates for stable performance [experimental]

### DIFF
--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -220,13 +220,13 @@ static LJ_AINLINE MSize snap_nextofs(GCtrace *T, SnapShot *snap)
 /* Round-robin penalty cache for bytecodes leading to aborted traces. */
 typedef struct HotPenalty {
   MRef pc;		/* Starting bytecode PC. */
-  uint16_t val;		/* Penalty value, i.e. hotcount start. */
+  uint32_t val;		/* Penalty value, i.e. hotcount start. */
   uint16_t reason;	/* Abort reason (really TraceErr). */
 } HotPenalty;
 
 #define PENALTY_SLOTS	64	/* Penalty cache slot. Must be a power of 2. */
 #define PENALTY_MIN	(36*2)	/* Minimum penalty value. */
-#define PENALTY_MAX	60000	/* Maximum penalty value. */
+#define PENALTY_MAX	6000000	/* Maximum penalty value. */
 #define PENALTY_RNDBITS	4	/* # of random bits to add to penalty value. */
 
 /* Round-robin backpropagation cache for narrowing conversions. */

--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -568,7 +568,8 @@ static void rec_loop_interp(jit_State *J, const BCIns *pc, LoopEvent ev)
 /* Handle the case when an already compiled loop op is hit. */
 static void rec_loop_jit(jit_State *J, TraceNo lnk, LoopEvent ev)
 {
-  if (J->parent == 0 && J->exitno == 0) {  /* Root trace hit an inner loop. */
+  /* Root trace hit an inner loop. */
+  if (J->parent == 0 && J->exitno == 0 && !innerloopleft(J, J->startpc)) {
     /* Better let the inner loop spawn a side trace back here. */
     lj_trace_err(J, LJ_TRERR_LINNER);
   } else if (ev != LOOPEV_LEAVE) {  /* Side trace enters a compiled loop. */

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -327,7 +327,7 @@ static void penalty_pc(jit_State *J, GCproto *pt, BCIns *pc, TraceError e)
   J->penaltyslot = (J->penaltyslot + 1) & (PENALTY_SLOTS-1);
   setmref(J->penalty[i].pc, pc);
 setpenalty:
-  J->penalty[i].val = (uint16_t)val;
+  J->penalty[i].val = val;
   J->penalty[i].reason = e;
   hotcount_set(J2GG(J), pc+1, val);
 }

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -253,6 +253,8 @@ int lj_trace_flushall(lua_State *L)
   J->freetrace = 0;
   /* Clear penalty cache. */
   memset(J->penalty, 0, sizeof(J->penalty));
+  /* Reset hotcounts. */
+  lj_dispatch_init_hotcount(J2G(J));
   /* Free the whole machine code and invalidate all exit stub groups. */
   lj_mcode_free(J);
   memset(J->exitstubgroup, 0, sizeof(J->exitstubgroup));

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -393,6 +393,7 @@ static void trace_stop(jit_State *J)
   TraceNo traceno = J->cur.traceno;
   GCtrace *T = J->curfinal;
   lua_State *L;
+  int i;
 
   switch (op) {
   case BC_FORL:
@@ -443,6 +444,11 @@ static void trace_stop(jit_State *J)
   lj_mcode_commit(J, J->cur.mcode);
   J->postproc = LJ_POST_NONE;
   trace_save(J, T);
+
+  /* Clear any penalty after successful recording. */
+  for (i = 0; i < PENALTY_SLOTS; i++)
+    if (mref(J->penalty[i].pc, const BCIns) == pc)
+      J->penalty[i].val = PENALTY_MIN;
 
   L = J->L;
 }


### PR DESCRIPTION
This branch contains some experimental changes for making the JIT blacklist bytecodes more conservatively (#100):

- f7212ccb97ea39effb9c311b5a7affc8f66d3bf2: Clear the penalty cache after each successful trace (we only want to blacklist bytecodes that abort many times **in a row**.)
- 01dc8448637f80151fa8de4ede765ff81efe7536: Increase `HOTCOUNT_MAX` to allow more trace attempts before blacklisting. (This can probably be rewritten better.)
- a720595aed834541f61ad1edfb75ac8c45a4c5dd: Reset HOTCOUNT table after JIT flush. This is intended to address a situation where the JIT chooses an extremely sub-optimal set of traces after a flush, but for some reason I don't think it is actually effective.
- ce6fbb4240fa3d626b6a1eb8ddafd3d36b335751: Relax heuristic for root trace meeting JIT loop. If this happens persistently then accept the trace so that aborts don't lead to blacklisting.

These changes were made while debugging a router-like networking application. The high-level problem was that after several hours or days of operation the performance would suddenly collapse. The low-level cause was that the application is occasionally compiling new traces while it executes (~1250+ traces total) and eventually after "one abort too many" the JIT would blacklist an important bytecode and a lot of processing then be suddenly moved onto the interpreter and lead to a massive drop in throughput.

The interesting thing about this application is the large number of traces it requires. There are a lot of root traces (generated code) and these require growing sets of side traces (hashtable routines unrolled/specialized on different table size / occupancy / etc.) This set of traces can probably be pruned substantially with some application-level changes but meanwhile it is a valuable stress test for the JIT.

Review would be welcome! cc @javierguerragiraldez and @corsix in case you guys are interested.