### PR TITLE
lj_record.c: Record IFUNC/IFUNCV the same as FUNC/FUNCV

### DIFF
--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -2284,8 +2284,6 @@ void lj_record_ins(jit_State *J)
   case BC_IFORL:
   case BC_IITERL:
   case BC_ILOOP:
-  case BC_IFUNCF:
-  case BC_IFUNCV:
     lj_trace_err(J, LJ_TRERR_BLACKL);
     break;
 
@@ -2297,6 +2295,7 @@ void lj_record_ins(jit_State *J)
   /* -- Function headers -------------------------------------------------- */
 
   case BC_FUNCF:
+  case BC_IFUNCF:
     rec_func_lua(J);
     break;
   case BC_JFUNCF:
@@ -2304,6 +2303,7 @@ void lj_record_ins(jit_State *J)
     break;
 
   case BC_FUNCV:
+  case BC_IFUNCV:
     rec_func_vararg(J);
     rec_func_lua(J);
     break;


### PR DESCRIPTION
Record calls to blacklisted functions the same way as calls to uncompiled functions. This allows for the possibility that a blacklisted function can be successfully recorded as part of a larger trace.

If the function truly cannot be compiled into other traces then it will continue to abort and lead to more blacklistings, at the cost of some extra "due diligence" by the JIT to avoid false-negatives. This is perfectly in line with the RaptorJIT goal of blacklisting code conservatively and taking pains to find successful traces.

This change does not affect the treatment blacklisted loops. Those may or may not deserve further consideration.

Resolves raptorjit/raptorjit#119.