### PR TITLE
VMProfile 3: Updated profiler data collection

### DIFF
--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -438,6 +438,7 @@ typedef struct GCtab {
 
 /* VM states. */
 enum {
+  /* VM states. */
   LJ_VMST_INTERP,	/* Interpreter. */
   LJ_VMST_C,		/* C function. */
   LJ_VMST_GC,		/* Garbage collector. */
@@ -445,6 +446,14 @@ enum {
   LJ_VMST_RECORD,	/* Trace recorder. */
   LJ_VMST_OPT,		/* Optimizer. */
   LJ_VMST_ASM,		/* Assembler. */
+  /* JIT trace states.
+  ** These are "abstract" states that logically exist but are never
+  ** directly used for the value of global_State.vmstate.
+  */
+  LJ_VMST_HEAD,		/* Trace mcode before loop */
+  LJ_VMST_LOOP,		/* Trace mcode inside loop */
+  LJ_VMST_JGC,		/* GC invoked from JIT mcode. */
+  LJ_VMST_FFI,		/* Other code outside trace mcode */
   LJ_VMST__MAX
 };
 

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -527,6 +527,7 @@ typedef struct global_State {
   GCState gc;		/* Garbage collector. */
   volatile int32_t vmstate;   /* VM state or current JIT code trace number. */
   volatile int32_t gcvmstate; /* Previous VM state (only when state is GC). */
+  volatile int32_t lasttrace; /* VM state before exit to interpreter. */
   SBuf tmpbuf;		/* Temporary string buffer. */
   GCstr strempty;	/* Empty string. */
   uint8_t stremptyz;	/* Zero terminator of empty string. */

--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -88,7 +88,7 @@ static void vmprofile_signal(int sig, siginfo_t *si, void *data)
       }
     }
     /* Handle overflow from individual trace counters. */
-    trace = trace <= LJ_VMPROFILE_TRACE_MAX ? trace : LJ_VMPROFILE_TRACE_MAX+1;
+    trace = trace <= LJ_VMPROFILE_TRACE_MAX ? trace : 0;
     /* Phew! We have calculated the indices and now we can bump the counter. */
     assert(vmstate >= 0 && vmstate <= LJ_VMST__MAX);
     profile->count[trace][vmstate]++;

--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -90,7 +90,8 @@ static void vmprofile_signal(int sig, siginfo_t *si, void *data)
     /* Handle overflow from individual trace counters. */
     trace = trace <= LJ_VMPROFILE_TRACE_MAX ? trace : 0;
     /* Phew! We have calculated the indices and now we can bump the counter. */
-    assert(vmstate >= 0 && vmstate <= LJ_VMST__MAX);
+    lua_assert(vmstate >= 0 && vmstate <= LJ_VMST__MAX);
+    lua_assert(trace >= 0 && trace <= LJ_VMPROFILE_TRACE_MAX);
     profile->count[trace][vmstate]++;
   }
 }

--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -153,7 +153,7 @@ LUA_API int luaJIT_vmprofile_close(lua_State *L, void *ud)
 LUA_API int luaJIT_vmprofile_select(lua_State *L, void *ud)
 {
   setlightudV(L->base, checklightudptr(L, profile));
-  profile = (VMProfile *)ud;
+  vmprofile_set_profile(ud);
   return 1;
 }
 

--- a/src/lj_vmprofile.h
+++ b/src/lj_vmprofile.h
@@ -25,7 +25,7 @@ typedef struct VMProfileTraceCount {
 /* Complete set of counters for VM and traces. */
 typedef struct VMProfile {
   uint32_t magic;               /* 0x1d50f007 */
-  uint16_t major, minor;        /* 2, 0 */
+  uint16_t major, minor;        /* 3, 0 */
   /* The profiler always bumps exactly one VM state counter. */
   VMProfileCount vm[LJ_VMST__MAX];
   /* The profiler also bumps exactly one per-trace counter for the

--- a/src/lj_vmprofile.h
+++ b/src/lj_vmprofile.h
@@ -6,7 +6,6 @@
 #ifndef _LJ_VMPROFILE_H
 #define _LJ_VMPROFILE_H
 
-
 /* Counters are 64-bit to avoid overflow even in long running processes. */
 typedef uint64_t VMProfileCount;
 
@@ -18,15 +17,23 @@ typedef uint64_t VMProfileCount;
 typedef struct VMProfileTraceCount {
   VMProfileCount head;          /* Head of the trace (non-looping part) */
   VMProfileCount loop;          /* Loop of the trace */
-  VMProfileCount other;         /* Outside the trace mcode (unidentified) */
+  VMProfileCount ffi;           /* Outside the trace mcode (assumed FFI) */
   VMProfileCount gc;            /* Garbage collection from this trace. */
+  VMProfileCount interp;        /* Interpreter due to exit from this trace. */
 } VMProfileTraceCount;
 
 /* Complete set of counters for VM and traces. */
 typedef struct VMProfile {
   uint32_t magic;               /* 0x1d50f007 */
   uint16_t major, minor;        /* 2, 0 */
+  /* The profiler always bumps exactly one VM state counter. */
   VMProfileCount vm[LJ_VMST__MAX];
+  /* The profiler also bumps exactly one per-trace counter for the
+  ** currently executing trace (JIT mode) or for the most recently
+  ** executing trace (interpreter mode.) This bump is skipped only if
+  ** no trace can be identified for some reason e.g. none have been
+  ** recorded.
+  **/
   VMProfileTraceCount trace[LJ_VMPROFILE_TRACE_MAX+1];
 } VMProfile;
 

--- a/src/lj_vmprofile.h
+++ b/src/lj_vmprofile.h
@@ -10,31 +10,22 @@
 typedef uint64_t VMProfileCount;
 
 /* Maximum trace number for distinct counter buckets. Traces with
-   higher numbers will be counted together in bucket zero. */
+   higher numbers will be counted together in a shared overflow bucket. */
 #define LJ_VMPROFILE_TRACE_MAX 4096
-
-/* Traces have separate counters for different machine code regions. */
-typedef struct VMProfileTraceCount {
-  VMProfileCount head;          /* Head of the trace (non-looping part) */
-  VMProfileCount loop;          /* Loop of the trace */
-  VMProfileCount ffi;           /* Outside the trace mcode (assumed FFI) */
-  VMProfileCount gc;            /* Garbage collection from this trace. */
-  VMProfileCount interp;        /* Interpreter due to exit from this trace. */
-} VMProfileTraceCount;
 
 /* Complete set of counters for VM and traces. */
 typedef struct VMProfile {
   uint32_t magic;               /* 0x1d50f007 */
-  uint16_t major, minor;        /* 3, 0 */
-  /* The profiler always bumps exactly one VM state counter. */
-  VMProfileCount vm[LJ_VMST__MAX];
-  /* The profiler also bumps exactly one per-trace counter for the
-  ** currently executing trace (JIT mode) or for the most recently
-  ** executing trace (interpreter mode.) This bump is skipped only if
-  ** no trace can be identified for some reason e.g. none have been
-  ** recorded.
+  uint16_t major, minor;        /* 4, 0 */
+  /* Profile counters are stored in a 2D matrix of count[trace][state].
+  **
+  ** The profiler attempts to attribute each sample to one vmstate and
+  ** one trace. The vmstate is an LJ_VMST_* constant. The trace is
+  ** either 1..4096 (counter for one individual trace) or 0 (shared
+  ** counter for all higher-numbered traces and for samples that can't
+  ** be attributed to a specific trace at all.)
   **/
-  VMProfileTraceCount trace[LJ_VMPROFILE_TRACE_MAX+1];
+  VMProfileCount count[LJ_VMPROFILE_TRACE_MAX+1][LJ_VMST__MAX];
 } VMProfile;
 
 /* Functions that should be accessed via FFI. */

--- a/src/vm_x64.dasc
+++ b/src/vm_x64.dasc
@@ -2018,6 +2018,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  set_vmstate EXIT
   |  mov [DISPATCH+DISPATCH_J(exitno)], RCd
   |  mov [DISPATCH+DISPATCH_J(parent)], RAd
+  |  mov dword [DISPATCH+DISPATCH_GL(lasttrace)], RAd
   |  sub rsp, 16*8			// Room for SSE regs.
   |  add rbp, -128
   |  movsd qword [rbp-8],   xmm15; movsd qword [rbp-16],  xmm14
@@ -2048,6 +2049,11 @@ static void build_subroutines(BuildCtx *ctx)
   |  // RD = MULTRES or negated error code, BASE, PC and DISPATCH set.
   |  // Restore additional callee-save registers only used in compiled code.
   |  lea RA, [rsp+16]
+  |  // Record which trace exited to the interpreter (if called from a trace)
+  |  mov TMPRd, dword [DISPATCH+DISPATCH_GL(vmstate)]
+  |  cmp TMPRd, 1
+  |  jb >1
+  |  mov dword [DISPATCH+DISPATCH_GL(lasttrace)], TMPRd
   |1:
   |  mov r13, [RA-8]
   |  mov r12, [RA]
@@ -2062,9 +2068,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov L:RB->base, BASE
   |  mov qword [DISPATCH+DISPATCH_GL(jit_base)], 0
   |  mov TMPRd, dword [DISPATCH+DISPATCH_GL(vmstate)]
-  |  // Record which trace exited to the interpreter, then switch state
-  |  mov TMPRd, dword [DISPATCH+DISPATCH_GL(vmstate)]
-  |  mov dword [DISPATCH+DISPATCH_GL(lasttrace)], TMPRd
   |  set_vmstate INTERP
   |  // Modified copy of ins_next which handles function header dispatch, too.
   |  mov RCd, [PC]

--- a/src/vm_x64.dasc
+++ b/src/vm_x64.dasc
@@ -2061,6 +2061,10 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov KBASE, [KBASE+PC2PROTO(k)]
   |  mov L:RB->base, BASE
   |  mov qword [DISPATCH+DISPATCH_GL(jit_base)], 0
+  |  mov TMPRd, dword [DISPATCH+DISPATCH_GL(vmstate)]
+  |  // Record which trace exited to the interpreter, then switch state
+  |  mov TMPRd, dword [DISPATCH+DISPATCH_GL(vmstate)]
+  |  mov dword [DISPATCH+DISPATCH_GL(lasttrace)], TMPRd
   |  set_vmstate INTERP
   |  // Modified copy of ins_next which handles function header dispatch, too.
   |  mov RCd, [PC]


### PR DESCRIPTION
This branch updates the data collected by the VMProfile profiler. The highlight of this branch is to propose a solution to the long-standing problem of "How to profile and optimize code that runs interpreted?" (#65).

### Problem of tracing interpreted code

The draft optimization manual (#68) says this:

> If the application is spending time in the interpreter then we need to diagnose why.

However we have never had a straightforward way to do this. The profiler tells us that we are spending time in the interpreter, but it does not tell us why. This leaves us to read through all of the trace aborts in the JIT log looking for the root cause, and that becomes a "needle in a haystack" problem in larger programs where there are many aborts and we don't know which few are actually significant.

This is bad because we need the profiler to provide us with *actionable* information. If we are spending time in the interpreter then that is a problem, and we need to know how to solve it.

### Proposed solution

The proposed solution is simple: time spent in the interpreter will be "blamed" on the most recently exited trace.

The profiler will be able to rank traces according to much time they caused the interpreter to run. This will be actionable: each trace will end at a specific line of code, and to make the code run fast we will either need to make that line of code trace successfully or, when that is impossible for reasons such as NYIs, at least make some other nearby code trace successfully so that we will re-enter JIT code and minimize time in the interpreter.

### Next steps

The next steps are:

- [ ] Update the [Studio](https://github.com/studio/studio) tooling to support the new vmprofile features.
- [ ] See how practical this approach is on open hard-to-optimize problems like snabbco/snabb#1239.
