### PR TITLE
Remove feature to compress GCproto.lineinfo

### DIFF
--- a/src/lj_bcread.c
+++ b/src/lj_bcread.c
@@ -361,7 +361,7 @@ GCproto *lj_bcread_proto(LexState *ls)
   pt->firstline = firstline;
   pt->numline = numline;
   if (sizedbg) {
-    MSize sizeli = (sizebc-1) / sizeof(BCLine);
+    MSize sizeli = (sizebc-1) * sizeof(BCLine);
     setmref(pt->lineinfo, (char *)pt + ofsdbg);
     setmref(pt->uvinfo, (char *)pt + ofsdbg + sizeli);
     bcread_dbg(ls, pt, sizedbg);

--- a/src/lj_bcread.c
+++ b/src/lj_bcread.c
@@ -151,7 +151,7 @@ static uint32_t bcread_uleb128_33(LexState *ls)
 /* Read debug info of a prototype. */
 static void bcread_dbg(LexState *ls, GCproto *pt, MSize sizedbg)
 {
-  uint32_t *lineinfo = proto_lineinfo(pt);
+  uint32_t *lineinfo = (uint32_t*)proto_lineinfo(pt);
   bcread_block(ls, lineinfo, sizedbg);
   /* Swap lineinfo if the endianess differs. */
   if (bcread_swap(ls)) {

--- a/src/lj_bcread.c
+++ b/src/lj_bcread.c
@@ -151,18 +151,12 @@ static uint32_t bcread_uleb128_33(LexState *ls)
 /* Read debug info of a prototype. */
 static void bcread_dbg(LexState *ls, GCproto *pt, MSize sizedbg)
 {
-  void *lineinfo = (void *)proto_lineinfo(pt);
+  uint32_t *lineinfo = proto_lineinfo(pt);
   bcread_block(ls, lineinfo, sizedbg);
   /* Swap lineinfo if the endianess differs. */
-  if (bcread_swap(ls) && pt->numline >= 256) {
-    MSize i, n = pt->sizebc-1;
-    if (pt->numline < 65536) {
-      uint16_t *p = (uint16_t *)lineinfo;
-      for (i = 0; i < n; i++) p[i] = (uint16_t)((p[i] >> 8)|(p[i] << 8));
-    } else {
-      uint32_t *p = (uint32_t *)lineinfo;
-      for (i = 0; i < n; i++) p[i] = lj_bswap(p[i]);
-    }
+  if (bcread_swap(ls)) {
+    int i;
+    for (i = 0; i < pt->sizebc-1; i++) lineinfo[i] = lj_bswap(lineinfo[i]);
   }
 }
 
@@ -367,7 +361,7 @@ GCproto *lj_bcread_proto(LexState *ls)
   pt->firstline = firstline;
   pt->numline = numline;
   if (sizedbg) {
-    MSize sizeli = (sizebc-1) << (numline < 256 ? 0 : numline < 65536 ? 1 : 2);
+    MSize sizeli = (sizebc-1) / sizeof(BCLine);
     setmref(pt->lineinfo, (char *)pt + ofsdbg);
     setmref(pt->uvinfo, (char *)pt + ofsdbg + sizeli);
     bcread_dbg(ls, pt, sizedbg);

--- a/src/lj_debug.c
+++ b/src/lj_debug.c
@@ -113,12 +113,7 @@ BCLine lj_debug_line(GCproto *pt, BCPos pc)
     BCLine first = pt->firstline;
     if (pc == pt->sizebc) return first + pt->numline;
     if (pc-- == 0) return first;
-    if (pt->numline < 256)
-      return first + (BCLine)((const uint8_t *)lineinfo)[pc];
-    else if (pt->numline < 65536)
-      return first + (BCLine)((const uint16_t *)lineinfo)[pc];
-    else
-      return first + (BCLine)((const uint32_t *)lineinfo)[pc];
+    return first + ((BCLine *)lineinfo)[pc];
   }
   return 0;
 }
@@ -497,16 +492,12 @@ int lj_debug_getinfo(lua_State *L, const char *what, lj_Debug *ar, int ext)
     if (isluafunc(fn)) {
       GCtab *t = lj_tab_new(L, 0, 0);
       GCproto *pt = funcproto(fn);
-      const void *lineinfo = proto_lineinfo(pt);
+      const uint32_t *lineinfo = proto_lineinfo(pt);
       if (lineinfo) {
 	BCLine first = pt->firstline;
-	int sz = pt->numline < 256 ? 1 : pt->numline < 65536 ? 2 : 4;
 	MSize i, szl = pt->sizebc-1;
 	for (i = 0; i < szl; i++) {
-	  BCLine line = first +
-	    (sz == 1 ? (BCLine)((const uint8_t *)lineinfo)[i] :
-	     sz == 2 ? (BCLine)((const uint16_t *)lineinfo)[i] :
-	     (BCLine)((const uint32_t *)lineinfo)[i]);
+	  BCLine line = first + lineinfo[i];
 	  setboolV(lj_tab_setint(L, t, line), 1);
 	}
       }

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -345,7 +345,7 @@ typedef struct GCproto {
 
 #define proto_chunkname(pt)	(strref((pt)->chunkname))
 #define proto_chunknamestr(pt)	(strdata(proto_chunkname((pt))))
-#define proto_lineinfo(pt)	(mref((pt)->lineinfo, const void))
+#define proto_lineinfo(pt)	(mref((pt)->lineinfo, const uint32_t))
 #define proto_uvinfo(pt)	(mref((pt)->uvinfo, const uint8_t))
 #define proto_varinfo(pt)	(mref((pt)->varinfo, const uint8_t))
 

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -312,7 +312,7 @@ typedef struct GCproto {
   GCRef chunkname;	/* Name of the chunk this function was defined in. */
   BCLine firstline;	/* First line of the function definition. */
   BCLine numline;	/* Number of lines for the function definition. */
-  MRef lineinfo;	/* Compressed map from bytecode ins. to source line. */
+  MRef lineinfo;	/* Map from bytecode ins. to source line. */
   MRef uvinfo;		/* Upvalue names. */
   MRef varinfo;		/* Names and compressed extents of local variables. */
 } GCproto;


### PR DESCRIPTION
The source code line number of each bytecode is now always stored in
memory as a 32-bit number.

Previously a simple compression scheme was used: an 8-bit number was
used for <256 line functions, a 16-bit number for <64K line functions,
and a 32-bit number otherwise.

This specific optimization is not appropraite for RaptorJIT. On the
one hand there will never be a practical benefit on any server
platform because the amount of memory involved is miniscule, and on
the other hand it complicates the JIT data structures that need to be
understood by new maintainers and also supported in external tools
like [Studio](http://github.com/studio/studio).

(Studio needs to understand the RaptorJIT data structures and in this
case I decided to do that by removing code from RaptorJIT rather than
adding code to Studio.)