### PR TITLE
Statically allocate JIT temp buffers

### DIFF
--- a/src/lj_iropt.h
+++ b/src/lj_iropt.h
@@ -24,13 +24,10 @@ static LJ_AINLINE void lj_ir_set_(jit_State *J, uint16_t ot, IRRef1 a, IRRef1 b)
 #define lj_ir_set(J, ot, a, b) \
   lj_ir_set_(J, (uint16_t)(ot), (IRRef1)(a), (IRRef1)(b))
 
-/* Get ref of next IR instruction and optionally grow IR.
-** Note: this may invalidate all IRIns*!
-*/
+/* Get ref of next IR instruction. */
 static LJ_AINLINE IRRef lj_ir_nextins(jit_State *J)
 {
   IRRef ref = J->cur.nins;
-  if (LJ_UNLIKELY(ref >= J->irtoplim)) lj_ir_growtop(J);
   J->cur.nins = ref + 1;
   return ref;
 }

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -333,8 +333,6 @@ typedef struct jit_State {
   uint32_t k32[LJ_K32__MAX];  /* Ditto for 4 byte constants. */
 
   IRIns *irbuf;		/* Temp. IR instruction buffer. Biased with REF_BIAS. */
-  IRRef irtoplim;	/* Upper limit of instuction buffer (biased). */
-  IRRef irbotlim;	/* Lower limit of instuction buffer (biased). */
   IRRef loopref;	/* Last loop reference or ref of final LOOP (or 0). */
 
   MSize sizesnap;	/* Size of temp. snapshot buffer. */

--- a/src/lj_opt_loop.c
+++ b/src/lj_opt_loop.c
@@ -283,15 +283,7 @@ static void loop_unroll(LoopState *lps)
   /* LOOP separates the pre-roll from the loop body. */
   emitir_raw(IRTG(IR_LOOP, IRT_NIL), 0, 0);
 
-  /* Grow snapshot buffer and map for copy-substituted snapshots.
-  ** Need up to twice the number of snapshots minus #0 and loop snapshot.
-  ** Need up to twice the number of entries plus fallback substitutions
-  ** from the loop snapshot entries for each new snapshot.
-  ** Caveat: both calls may reallocate J->cur.snap and J->cur.snapmap!
-  */
   onsnap = J->cur.nsnap;
-  lj_snap_grow_buf(J, 2*onsnap-2);
-  lj_snap_grow_map(J, J->cur.nsnapmap*2+(onsnap-2)*J->cur.snap[onsnap-1].nent);
 
   /* The loop snapshot is used for fallback substitutions. */
   loopsnap = &J->cur.snap[onsnap-1];

--- a/src/lj_snap.h
+++ b/src/lj_snap.h
@@ -15,18 +15,5 @@ LJ_FUNC void lj_snap_shrink(jit_State *J);
 LJ_FUNC IRIns *lj_snap_regspmap(GCtrace *T, SnapNo snapno, IRIns *ir);
 LJ_FUNC void lj_snap_replay(jit_State *J, GCtrace *T);
 LJ_FUNC const BCIns *lj_snap_restore(jit_State *J, void *exptr);
-LJ_FUNC void lj_snap_grow_buf_(jit_State *J, MSize need);
-LJ_FUNC void lj_snap_grow_map_(jit_State *J, MSize need);
-
-static LJ_AINLINE void lj_snap_grow_buf(jit_State *J, MSize need)
-{
-  if (LJ_UNLIKELY(need > J->sizesnap)) lj_snap_grow_buf_(J, need);
-}
-
-static LJ_AINLINE void lj_snap_grow_map(jit_State *J, MSize need)
-{
-  if (LJ_UNLIKELY(need > J->sizesnapmap)) lj_snap_grow_map_(J, need);
-}
-
 
 #endif

--- a/src/lj_state.c
+++ b/src/lj_state.c
@@ -158,6 +158,7 @@ static TValue *cpluaopen(lua_State *L, lua_CFunction dummy, void *ud)
 static void close_state(lua_State *L)
 {
   global_State *g = G(L);
+  jit_State *J = L2J(L);
   lj_func_closeuv(L, tvref(L->stack));
   lj_gc_freeall(g);
   lua_assert(gcref(g->gc.root) == obj2gco(L));
@@ -167,6 +168,9 @@ static void close_state(lua_State *L)
   lj_mem_freevec(g, g->strhash, g->strmask+1, GCRef);
   lj_buf_free(g, &g->tmpbuf);
   lj_mem_freevec(g, tvref(L->stack), L->stacksize, TValue);
+  lj_mem_free(g, J->snapmapbuf, J->sizesnapmap);
+  lj_mem_free(g, J->snapbuf, J->sizesnap);
+  lj_mem_free(g, J->irbuf-REF_BIAS, 65536*sizeof(IRIns));
   lua_assert(g->gc.total == sizeof(GG_State));
 #ifndef LUAJIT_USE_SYSMALLOC
   if (g->allocf == lj_alloc_f)
@@ -181,6 +185,7 @@ LUA_API lua_State *lua_newstate(lua_Alloc f, void *ud)
   GG_State *GG = (GG_State *)f(ud, NULL, 0, sizeof(GG_State));
   lua_State *L = &GG->L;
   global_State *g = &GG->g;
+  jit_State *J = &GG->J;
   if (GG == NULL || !checkptrGC(GG)) return NULL;
   memset(GG, 0, sizeof(GG_State));
   L->gct = ~LJ_TTHREAD;
@@ -206,6 +211,15 @@ LUA_API lua_State *lua_newstate(lua_Alloc f, void *ud)
   g->gc.total = sizeof(GG_State);
   g->gc.pause = LUAI_GCPAUSE;
   g->gc.stepmul = LUAI_GCMUL;
+  /* Statically allocate generous JIT scratch buffers. */
+  J->sizesnap = sizeof(SnapShot)*65536;
+  J->sizesnapmap = sizeof(SnapEntry)*65536;
+  J->snapbuf = (SnapShot *)lj_mem_new(L, J->sizesnap);
+  J->snapmapbuf = (SnapEntry *)lj_mem_new(L, J->sizesnapmap);
+  IRIns *irbufmem = (IRIns *)lj_mem_new(L, sizeof(IRIns)*65536);
+  if (irbufmem == NULL || J->snapbuf == NULL || J->snapmapbuf == NULL)
+    return NULL;
+  J->irbuf = irbufmem + REF_BIAS;
   lj_dispatch_init((GG_State *)L);
   L->status = LUA_ERRERR+1;  /* Avoid touching the stack upon memory error. */
   if (lj_vm_cpcall(L, NULL, NULL, cpluaopen) != 0) {

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -292,9 +292,6 @@ void lj_trace_freestate(global_State *g)
   }
 #endif
   lj_mcode_free(J);
-  lj_mem_freevec(g, J->snapmapbuf, J->sizesnapmap, SnapEntry);
-  lj_mem_freevec(g, J->snapbuf, J->sizesnap, SnapShot);
-  lj_mem_freevec(g, J->irbuf + J->irbotlim, J->irtoplim - J->irbotlim, IRIns);
   lj_mem_freevec(g, J->trace, J->sizetrace, GCRef);
 }
 


### PR DESCRIPTION
If we only need a few ~64K element arrays then just allocate those up front and don't worry about dynamically growing things. This is simpler, requires less code, and has no obvious practical downside.

Resolves #128.