### PR TITLE
[wip] Add log of recorded bytecodes (BCLogRec) to jit_State

### DIFF
--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -295,6 +295,13 @@ typedef struct FoldState {
   IRIns right[2];	/* Instruction referenced by right operand. */
 } FoldState;
 
+/* Log entry for a bytecode that was recorded. */
+typedef struct BCRecLog {
+  GCproto *pt;
+  BCPos pos;
+  int32_t framedepth;
+} BCRecLog;
+
 /* JIT compiler state. */
 typedef struct jit_State {
   GCtrace cur;		/* Current trace. */
@@ -339,6 +346,10 @@ typedef struct jit_State {
   SnapShot *snapbuf;	/* Temp. snapshot buffer. */
   SnapEntry *snapmapbuf;  /* Temp. snapshot map buffer. */
   MSize sizesnapmap;	/* Size of temp. snapshot map buffer. */
+
+  BCRecLog *bclog;	/* Start of of recorded bytecode log. */
+  BCRecLog *bclognext;	/* Next entry in the bytecode log. */
+  BCRecLog *bcloglast;	/* Last entry in the bytecode log. */
 
   PostProc postproc;	/* Required post-processing after execution. */
   uint8_t retryrec;	/* Retry recording. */

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -297,9 +297,9 @@ typedef struct FoldState {
 
 /* Log entry for a bytecode that was recorded. */
 typedef struct BCRecLog {
-  GCproto *pt;
-  BCPos pos;
-  int32_t framedepth;
+  GCproto *pt;		/* Prototype of bytecode function (or NULL). */
+  BCPos pos;		/* Position of bytecode in prototype. */
+  int32_t framedepth;	/* Frame depth when recorded. */
 } BCRecLog;
 
 /* JIT compiler state. */
@@ -348,8 +348,8 @@ typedef struct jit_State {
   MSize sizesnapmap;	/* Size of temp. snapshot map buffer. */
 
   BCRecLog *bclog;	/* Start of of recorded bytecode log. */
-  BCRecLog *bclognext;	/* Next entry in the bytecode log. */
-  BCRecLog *bcloglast;	/* Last entry in the bytecode log. */
+  uint32_t nbclog;	/* Number of logged bytecodes. */
+  uint32_t maxbclog;	/* Max entries in the bytecode log. */
 
   PostProc postproc;	/* Required post-processing after execution. */
   uint8_t retryrec;	/* Retry recording. */

--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -1864,6 +1864,13 @@ void lj_record_ins(jit_State *J)
   BCOp op;
   TRef ra, rb, rc;
 
+  if (J->bclognext < J->bcloglast) {
+    BCRecLog *log = J->bclognext++;
+    log->pt = J->pt;
+    log->pos = J->pt ? proto_bcpos(J->pt, J->pc) : -1;
+    log->framedepth = J->framedepth;
+  }
+
   /* Perform post-processing action before recording the next instruction. */
   if (LJ_UNLIKELY(J->postproc != LJ_POST_NONE)) {
     switch (J->postproc) {
@@ -2435,6 +2442,8 @@ void lj_record_setup(jit_State *J)
 
   J->bc_min = NULL;  /* Means no limit. */
   J->bc_extent = ~(MSize)0;
+
+  J->bclognext = J->bclog;
 
   /* Emit instructions for fixed references. Also triggers initial IR alloc. */
   emitir_raw(IRT(IR_BASE, IRT_PGC), J->parent, J->exitno);

--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -1864,8 +1864,8 @@ void lj_record_ins(jit_State *J)
   BCOp op;
   TRef ra, rb, rc;
 
-  if (J->bclognext < J->bcloglast) {
-    BCRecLog *log = J->bclognext++;
+  if (J->nbclog < J->maxbclog) {
+    BCRecLog *log = &J->bclog[J->nbclog++];
     log->pt = J->pt;
     log->pos = J->pt ? proto_bcpos(J->pt, J->pc) : -1;
     log->framedepth = J->framedepth;
@@ -2443,7 +2443,7 @@ void lj_record_setup(jit_State *J)
   J->bc_min = NULL;  /* Means no limit. */
   J->bc_extent = ~(MSize)0;
 
-  J->bclognext = J->bclog;
+  J->nbclog = 0;
 
   /* Emit instructions for fixed references. Also triggers initial IR alloc. */
   emitir_raw(IRT(IR_BASE, IRT_PGC), J->parent, J->exitno);

--- a/src/lj_state.c
+++ b/src/lj_state.c
@@ -217,8 +217,9 @@ LUA_API lua_State *lua_newstate(lua_Alloc f, void *ud)
   J->sizesnapmap = sizeof(SnapEntry)*65536;
   J->snapbuf = (SnapShot *)lj_mem_new(L, J->sizesnap);
   J->snapmapbuf = (SnapEntry *)lj_mem_new(L, J->sizesnapmap);
-  J->bclognext = J->bclog = (BCRecLog *)lj_mem_new(L, sizeof(BCRecLog)*65536);
-  J->bcloglast = J->bclog + 65535;
+  J->maxbclog = 65536;
+  J->bclog = (BCRecLog *)lj_mem_new(L, sizeof(BCRecLog)*J->maxbclog);
+  J->nbclog = 0;
   IRIns *irbufmem = (IRIns *)lj_mem_new(L, sizeof(IRIns)*65536);
   if (irbufmem == NULL || J->snapbuf == NULL || J->snapmapbuf == NULL)
     return NULL;

--- a/src/lj_state.c
+++ b/src/lj_state.c
@@ -168,6 +168,7 @@ static void close_state(lua_State *L)
   lj_mem_freevec(g, g->strhash, g->strmask+1, GCRef);
   lj_buf_free(g, &g->tmpbuf);
   lj_mem_freevec(g, tvref(L->stack), L->stacksize, TValue);
+  lj_mem_free(g, J->bclog, sizeof(BCRecLog)*65536);
   lj_mem_free(g, J->snapmapbuf, J->sizesnapmap);
   lj_mem_free(g, J->snapbuf, J->sizesnap);
   lj_mem_free(g, J->irbuf-REF_BIAS, 65536*sizeof(IRIns));
@@ -216,6 +217,8 @@ LUA_API lua_State *lua_newstate(lua_Alloc f, void *ud)
   J->sizesnapmap = sizeof(SnapEntry)*65536;
   J->snapbuf = (SnapShot *)lj_mem_new(L, J->sizesnap);
   J->snapmapbuf = (SnapEntry *)lj_mem_new(L, J->sizesnapmap);
+  J->bclognext = J->bclog = (BCRecLog *)lj_mem_new(L, sizeof(BCRecLog)*65536);
+  J->bcloglast = J->bclog + 65535;
   IRIns *irbufmem = (IRIns *)lj_mem_new(L, sizeof(IRIns)*65536);
   if (irbufmem == NULL || J->snapbuf == NULL || J->snapmapbuf == NULL)
     return NULL;


### PR DESCRIPTION
This is a work-in-progress branch to log each bytecode that is recorded for a trace.

The basic intention is to include the recorded bytecodes for each trace in the auditlog (#63). Then the tools can show the bytecodes for each trace (like LuaJIT `-jdump=b`) and even show which lines of source code were executed (via debug info mapping from bytecode to source.)

Open question: Can the bytecode log be copied from jit_State to GCtrace when a trace is completed? This would depend on the `GCproto*` pointers staying valid so we either need to be sure that each prototype referenced in the log is also referenced as a constant in the trace IR (I think so...?) or we need to teach the GC to traverse the log to keep the references alive.