### PR TITLE
lj_trace.c: unpatch blacklisted bytecodes when flushing traces

### DIFF
--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -251,6 +251,15 @@ int lj_trace_flushall(lua_State *L)
   }
   J->cur.traceno = 0;
   J->freetrace = 0;
+  /* Unpatch blacklisted byte codes. */
+  GCRef *p = &(G(L)->gc.root);
+  GCobj *o;
+  while ((o = gcref(*p)) != NULL) {
+    if (o->gch.gct == ~LJ_TPROTO) {
+      lj_trace_reenableproto(gco2pt(o));
+    }
+    p = &o->gch.nextgc;
+  }
   /* Clear penalty cache. */
   memset(J->penalty, 0, sizeof(J->penalty));
   /* Free the whole machine code and invalidate all exit stub groups. */


### PR DESCRIPTION
Resolve #125 by clearing all bytecode blacklistings when `jit.flush()` is called.

Code is written and tested by @alexandergall and here is his original comment on the commit:

> The blacklist is cleared by going through all prototype objects on the heap marked to contain patched bytecodes and revert all instances of `IFUNCF`, `IFORL`, `IITERL` and `ILOOP`.

The cost should be comparable to a full garbage collection, which seems acceptable in the context of `jit.flush()` that already does expensive work like re-tracing every function and regenerating all machine code. (If the traversal would ever become a practical performance issue then we could address this a simple index of some kind.)

(cherry picked from commit https://github.com/alexandergall/snabbswitch/commit/8beb311332a6c95ab1d2934f292f41563b878edb)