### PR TITLE
Add jit.unlikely() primitive

### DIFF
--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -105,6 +105,12 @@ LJLIB_CF(jit_tracebarrier)
   return 0;
 }
 
+/* Calling this function makes the trace recording consider an abort. */
+LJLIB_CF(jit_unlikely)		LJLIB_REC(.)
+{
+  return 0;
+}
+
 LJLIB_PUSH(top-5) LJLIB_SET(os)
 LJLIB_PUSH(top-4) LJLIB_SET(arch)
 LJLIB_PUSH(top-3) LJLIB_SET(version_num)

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -8,7 +8,6 @@
 
 #include "lj_obj.h"
 
-
 #include "lj_err.h"
 #include "lj_str.h"
 #include "lj_tab.h"
@@ -1148,6 +1147,15 @@ static void recff_debug_getmetatable(jit_State *J, RecordFFData *rd)
   }
   emitir(IRTG(mt ? IR_NE : IR_EQ, IRT_TAB), mtref, lj_ir_knull(J, IRT_TAB));
   J->base[0] = mt ? mtref : TREF_NIL;
+}
+
+/* -- JIT library fast functions ------------------------------------------ */
+
+static uint32_t recff_jit_unlikely(jit_State *J, RecordFFData *rd)
+{
+  int i;
+  if (J->parent == 0) lj_trace_err(J, LJ_TRERR_UNLIKELY);
+  return 0;
 }
 
 /* -- Record calls to fast functions -------------------------------------- */

--- a/src/lj_traceerr.h
+++ b/src/lj_traceerr.h
@@ -14,6 +14,7 @@ TREDEF(SNAPOV,	"too many snapshots")
 TREDEF(BLACKL,	"blacklisted")
 TREDEF(RETRY,	"retry recording")
 TREDEF(NYIBC,	"NYI: bytecode %d")
+TREDEF(UNLIKELY,"unlikely operation in root trace")
 
 /* Recording loop ops. */
 TREDEF(LLEAVE,	"leaving loop in root trace")

--- a/testsuite/bench/roulette.lua
+++ b/testsuite/bench/roulette.lua
@@ -12,6 +12,7 @@ local die  = 0
 
 for i = 1, population do
    if math.random(6) == 6 then
+      jit.unlikely()
       die = die + 1
    else
       live = live + 1


### PR DESCRIPTION
The primitive function `jit.unlikely()` tells the JIT that it has taken a branch that is expected to be relatively unusual. The JIT takes this into account and attempts to prioritize alternative code paths for optimization.

Specifically the JIT will attempt to put `jit.unlikely()` calls on side traces instead of root traces. Calling `jit.unlikely()` while recording a root trace causes an abort, which will lead to a new trace being compiled later that hopefully takes a more frequent path. Calls to `jit.unlikely()` are accepted on side-traces. They always compile into no-ops.

### Example

This feature can solve the "Side-trace Russian Roulette Problem"
 (https://github.com/LuaJIT/LuaJIT/issues/218) by making sure the JIT does not misread the bias of a loop. Consider this updated inner loop:


```lua
for i = 1, population do
   if math.random(6) == 6 then
      jit.unlikely()  -- This branch is rare (chosen 1/6)
      die = die + 1
   else               -- This branch is common (chosen 5/6)
      live = live + 1
   end
end
```

Here the `jit.unlikely()` prevents the rare branch from being chosen for the root trace i.e. being the branch eligible for "loop optimization". This makes the JIT always select the alternative instead which is to optimize for the actual bias of the loop. This does solve the problem and make the benchmark always perform the same way (instead of performing poorly on 1/6 runs when the wrong root trace is formed.)

### TODO

- [ ] Consider whether this is user-friendly.
- [ ] Check for unintended consequences.
- [ ] Ensure it never leads to blacklisting.

