### PR TITLE
lj_parse.c, lj_debug.c: Remove clever tricks in lineinfo encoding

### DIFF
--- a/src/lj_debug.c
+++ b/src/lj_debug.c
@@ -110,10 +110,7 @@ BCLine lj_debug_line(GCproto *pt, BCPos pc)
 {
   const void *lineinfo = proto_lineinfo(pt);
   if (pc <= pt->sizebc && lineinfo) {
-    BCLine first = pt->firstline;
-    if (pc == pt->sizebc) return first + pt->numline;
-    if (pc-- == 0) return first;
-    return first + ((BCLine *)lineinfo)[pc];
+    return mref(lineinfo, uint32_t)[pc];
   }
   return 0;
 }


### PR DESCRIPTION
Remove two clever tricks whose benefits don't justify their complexity:

1. The GCproto.lineinfo table used to exclude the first and last bytecodes. The line numbers of those bytecodes had to be calculated as a special case (using other state in the GCproto struct.) Now every bytecode has an entry in the lineinfo table and is treated the same.
2. The GCproto.lineinfo table used to store delta values relative to the first line. Now the absolute line number is stored. (The deltas helped with a compression scheme that has previously been removed from RaptorJIT.)

Remove the `#ifdef` option to build the VM without linenumber debug support too. RaptorJIT does not want this kind of feature parameterized with `#ifdef` in the VM code.