### PR TITLE
Support "one-liner" usage of jit.vmprofile.open()

### DIFF
--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -145,6 +145,12 @@ void vmprofile_start(lua_State *L)
   }
 }
 
+void vmprofile_stop()
+{
+  stop_timer();
+  started = 0;
+}
+
 /* -- Lua API ------------------------------------------------------------- */
 
 LUA_API int luaJIT_vmprofile_open(lua_State *L, const char *str, int noselect, int nostart)
@@ -181,7 +187,7 @@ LUA_API int luaJIT_vmprofile_start(lua_State *L)
 
 LUA_API int luaJIT_vmprofile_stop(lua_State *L)
 {
-  stop_timer();
+  vmprofile_stop();
   return 0;
 }
 

--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -32,38 +32,9 @@ static struct {
   struct sigaction oldsa;
 } state;
 
-/* -- State that the application can manage via FFI ----------------------- */
+static int started;
 
 static VMProfile *profile;      /* Current counters */
-
-/* How much memory to allocate for profiler counters. */
-int vmprofile_get_profile_size() {
-  return sizeof(VMProfile);
-}
-
-/* Open a counter file on disk and returned the mmapped data structure. */
-void *vmprofile_open_file(const char *filename)
-{
-  int fd;
-  void *ptr = MAP_FAILED;
-  if (((fd = open(filename, O_RDWR|O_CREAT, 0666)) != -1) &&
-      ((ftruncate(fd, sizeof(VMProfile))) != -1) &&
-      ((ptr = mmap(NULL, sizeof(VMProfile), PROT_READ|PROT_WRITE,
-                   MAP_SHARED, fd, 0)) != MAP_FAILED)) {
-    memset(ptr, 0, sizeof(VMProfile));
-  }
-  if (fd != -1) close(fd);
-  return ptr == MAP_FAILED ? NULL : ptr;
-}
-
-/* Set the memory where the next samples will be counted. 
-   Size of the memory must match vmprofile_get_profile_size(). */
-void vmprofile_set_profile(void *counters) {
-  profile = (VMProfile*)counters;
-  profile->magic = 0x1d50f007;
-  profile->major = 4;
-  profile->minor = 0;
-}
 
 /* -- Signal handler ------------------------------------------------------ */
 
@@ -133,13 +104,56 @@ static void stop_timer()
   sigaction(SIGPROF, NULL, &state.oldsa);
 }
 
+/* -- State that the application can manage via FFI ----------------------- */
+
+/* How much memory to allocate for profiler counters. */
+int vmprofile_get_profile_size() {
+  return sizeof(VMProfile);
+}
+
+/* Open a counter file on disk and returned the mmapped data structure. */
+void *vmprofile_open_file(const char *filename)
+{
+  int fd;
+  void *ptr = MAP_FAILED;
+  if (((fd = open(filename, O_RDWR|O_CREAT, 0666)) != -1) &&
+      ((ftruncate(fd, sizeof(VMProfile))) != -1) &&
+      ((ptr = mmap(NULL, sizeof(VMProfile), PROT_READ|PROT_WRITE,
+                   MAP_SHARED, fd, 0)) != MAP_FAILED)) {
+    memset(ptr, 0, sizeof(VMProfile));
+  }
+  if (fd != -1) close(fd);
+  return ptr == MAP_FAILED ? NULL : ptr;
+}
+
+/* Set the memory where the next samples will be counted. 
+   Size of the memory must match vmprofile_get_profile_size(). */
+void vmprofile_set_profile(void *counters) {
+  profile = (VMProfile*)counters;
+  profile->magic = 0x1d50f007;
+  profile->major = 4;
+  profile->minor = 0;
+}
+
+void vmprofile_start(lua_State *L)
+{
+  if (!started) {
+    memset(&state, 0, sizeof(state));
+    state.g = G(L);
+    start_timer(1);               /* Sample every 1ms */
+    started = 1;
+  }
+}
+
 /* -- Lua API ------------------------------------------------------------- */
 
-LUA_API int luaJIT_vmprofile_open(lua_State *L, const char *str)
+LUA_API int luaJIT_vmprofile_open(lua_State *L, const char *str, int noselect, int nostart)
 {
   void *ptr;
   if ((ptr = vmprofile_open_file(str)) != NULL) {
     setlightudV(L->base, checklightudptr(L, ptr));
+    if (!noselect) vmprofile_set_profile(ptr);
+    if (!nostart) vmprofile_start(L);
   } else {
     setnilV(L->base);
   }
@@ -161,9 +175,7 @@ LUA_API int luaJIT_vmprofile_select(lua_State *L, void *ud)
 
 LUA_API int luaJIT_vmprofile_start(lua_State *L)
 {
-  memset(&state, 0, sizeof(state));
-  state.g = G(L);
-  start_timer(1);               /* Sample every 1ms */
+  vmprofile_start(L);
   return 0;
 }
 

--- a/src/luajit.c
+++ b/src/luajit.c
@@ -465,12 +465,10 @@ static int runargs(lua_State *L, char **argv, int argn)
     case 'b':  /* LuaJIT extension. */
       return dobytecode(L, argv+i);
     case 'p': {
-      void *ptr;
-      if ((ptr = vmprofile_open_file(argv[++i])) != NULL) {
-        vmprofile_set_profile(ptr);
-        luaJIT_vmprofile_start(L);
-      } else {
-        fprintf(stderr, "unable to open vmprofile\n");
+      char *filename = argv[++i];
+      luaJIT_vmprofile_open(L, filename, 0, 0);
+      if (lua_isnil(L, -1)) {
+        fprintf(stderr, "unable to open vmprofile: %s\n", filename);
         fflush(stderr);
       }
       break;

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -66,7 +66,7 @@ LUA_API int luaJIT_setmode(lua_State *L, int idx, int mode);
 
 /* VM profiling API. */
 LUA_API int luaJIT_vmprofile_start(lua_State *L);
-LUA_API int luaJIT_vmprofile_open(lua_State *L, const char *str);
+LUA_API int luaJIT_vmprofile_open(lua_State *L, const char *str, int noselect, int nostart);
 LUA_API int luaJIT_vmprofile_select(lua_State *L, void *ud);
 LUA_API int luaJIT_vmprofile_close(lua_State *L, void *ud);
 LUA_API int luaJIT_vmprofile_stop(lua_State *L);


### PR DESCRIPTION
Make simple usage of VMProfile more convenient.

For example:

    jit.vmprofile.open("bigloop")   for i = 1, 1e9 do end
    jit.vmprofile.open("shortloop") for i = 1, 1e6 do end

This involves two changes to the jit.vmprofile API:

Preload the jit.vmprofile library, so that no require() is needed.

Make the default behavior of jit.vmprofile.open(filename) include
selecting the profile and enabling the timer. This way a single call
with a filename will enable live profiling to disk.

The slightly awkward aspect is that the jit.vmprofile.open() changes
are not quite backwards compatible. The old behavior was to not select
the new profile nor enable the timer (on the assumption that this will
be done separately.) This behavior can be accessed using new optional
arguments boolean arguments `noselect` and `noopen`:

    jit.vmprofile(filename, [noselect, noopen])