### PR TITLE
testsuite/bench: Fix awk parsing of perf output

### DIFF
--- a/testsuite/bench/default.nix
+++ b/testsuite/bench/default.nix
@@ -48,8 +48,8 @@ let benchmark = letter: name: src: args: run:
       for result in result/*.perf; do
         version=${name}
         benchmark=$(basename -s.perf -a $result)
-        instructions=$(awk -F, -e '$3 == "instructions" { print $1; }' $result)
-        cycles=$(      awk -F, -e '$3 == "cycles"       { print $1; }' $result)
+        instructions=$(awk -F, -e '$3 ~ "^instructions" { print $1; }' $result)
+        cycles=$(      awk -F, -e '$3 ~ "^cycles"       { print $1; }' $result)
         echo ${letter},$version,$benchmark,${toString run},$instructions,$cycles >> $out/bench.csv
       done
     '';


### PR DESCRIPTION
The awk code for extracting the instructions and cycles counts from the perf output was not working. Likely I had updated perf to an incompatible version and pushed that without testing. Naughty me.

This change was made while live coding on http://twitch.tv/lukegorrie :).