### PR TITLE
lj_str.c: Remove special-case string interning fast-path

### DIFF
--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -37,27 +37,6 @@ int32_t lj_str_cmp(GCstr *a, GCstr *b)
   return (int32_t)(a->len - b->len);
 }
 
-/* Fast string data comparison. Caveat: unaligned access to 1st string! */
-static LJ_AINLINE int str_fastcmp(const char *a, const char *b, MSize len)
-{
-  MSize i = 0;
-  lua_assert(len > 0);
-  lua_assert((((uintptr_t)a+len-1) & (LJ_PAGESIZE-1)) <= LJ_PAGESIZE-4);
-  do {  /* Note: innocuous access up to end of string + 3. */
-    uint32_t v = lj_getu32(a+i) ^ *(const uint32_t *)(b+i);
-    if (v) {
-      i -= len;
-#if LJ_LE
-      return (int32_t)i >= -3 ? (v << (32+(i<<3))) : 1;
-#else
-      return (int32_t)i >= -3 ? (v >> (32+(i<<3))) : 1;
-#endif
-    }
-    i += 4;
-  } while (i < len);
-  return 0;
-}
-
 /* Find fixed string p inside string s. */
 const char *lj_str_find(const char *s, const char *p, MSize slen, MSize plen)
 {
@@ -149,26 +128,14 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
   h ^= b; h -= lj_rol(b, 16);
   /* Check if the string has already been interned. */
   o = gcref(g->strhash[h & g->strmask]);
-  if (LJ_LIKELY((((uintptr_t)str+len-1) & (LJ_PAGESIZE-1)) <= LJ_PAGESIZE-4)) {
-    while (o != NULL) {
-      GCstr *sx = gco2str(o);
-      if (sx->len == len && str_fastcmp(str, strdata(sx), len) == 0) {
-	/* Resurrect if dead. Can only happen with fixstring() (keywords). */
-	if (isdead(g, o)) flipwhite(o);
-	return sx;  /* Return existing string. */
-      }
-      o = gcnext(o);
+  while (o != NULL) {
+    GCstr *sx = gco2str(o);
+    if (sx->len == len && memcmp(str, strdata(sx), len) == 0) {
+      /* Resurrect if dead. Can only happen with fixstring() (keywords). */
+      if (isdead(g, o)) flipwhite(o);
+      return sx;  /* Return existing string. */
     }
-  } else {  /* Slow path: end of string is too close to a page boundary. */
-    while (o != NULL) {
-      GCstr *sx = gco2str(o);
-      if (sx->len == len && memcmp(str, strdata(sx), len) == 0) {
-	/* Resurrect if dead. Can only happen with fixstring() (keywords). */
-	if (isdead(g, o)) flipwhite(o);
-	return sx;  /* Return existing string. */
-      }
-      o = gcnext(o);
-    }
+    o = gcnext(o);
   }
   /* Nope, create a new string. */
   s = lj_mem_newt(L, sizeof(GCstr)+len+1, GCstr);


### PR DESCRIPTION
Make `lj_str_new()` faster and more consistent by removing its "fast-path" special case.

The "fast-path" was bad because:

- It's a tricky custom memcmp routine that needs to be maintained.
- It is actually *slower* than the slow-path (builtin memcmp) on modern Linux/x86.
- The special casing could cause confusing performance in practice e.g. a totally unrelated memory allocation could bias an important buffer towards the fast-path or the slow-path and impact overall application performance.

The fast-path code was written in 2010 and a lot has happened since then e.g. many revisions of the CPU string instructions and GCC code and glibc code and so on. I think the optimization had simply bit-rotted.

Here is a [benchmark report](https://hydra.snabb.co/build/2920065/download/3/bench-jitter.png) comparing three RaptorJIT versions. The `life` benchmark is the relevant one, since it is dominated by string interning.

- `lukego-benchmark` is the code on this PR. It is fastest and does not have a separate fast-path and slow-path for string intern.
- `master` is the current master branch. This runs slow and that seems to be because it is biased towards the "fast-path".
- `old` is an older version of RaptorJIT. This one also runs fast and that seems to be because it is biased towards the "slow-path."

I am happy about this. I found some confusing performance, I traced it to a fancy fast-path/slow-path optimization, and then I fixed it by removing the fast-path. Simplicity wins today!

This "aha" was live streamed btw :) link: https://youtu.be/i4uCGsiV00c.