### PR TITLE
Add jit.seal(tab) primitive (early version)

### DIFF
--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -105,6 +105,13 @@ LJLIB_CF(jit_tracebarrier)
   return 0;
 }
 
+LJLIB_CF(jit_seal)
+{
+  GCtab *tab = lj_lib_checktab(L, 1);
+  tab->sealed = 1;
+  return 0;
+}
+
 LJLIB_PUSH(top-5) LJLIB_SET(os)
 LJLIB_PUSH(top-4) LJLIB_SET(arch)
 LJLIB_PUSH(top-3) LJLIB_SET(version_num)

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -424,6 +424,7 @@ typedef struct GCtab {
   uint32_t asize;	/* Size of array part (keys [0, asize-1]). */
   uint32_t hmask;	/* Hash part mask (size of hash part - 1). */
   MRef freetop;		/* Top of free elements. */
+  uint8_t sealed;	/* Is the table sealed? */
 } GCtab;
 
 #define sizetabcolo(n)	((n)*sizeof(TValue) + sizeof(GCtab))

--- a/src/lj_record.h
+++ b/src/lj_record.h
@@ -23,6 +23,8 @@ typedef struct RecordIndex {
   TRef mt;		/* Metatable reference. */
   TRef mobj;		/* Metamethod object reference. */
   int idxchain;		/* Index indirections left or 0 for raw lookup. */
+  IRRef rbstart;	/* Start IR reference for rollback. */
+  TRef origtab;		/* Original / outermost table (indexed object). */
 } RecordIndex;
 
 LJ_FUNC int lj_record_objcmp(jit_State *J, TRef a, TRef b,

--- a/src/lj_tab.c
+++ b/src/lj_tab.c
@@ -132,6 +132,7 @@ static GCtab *newtab(lua_State *L, uint32_t asize, uint32_t hbits)
   }
   if (hbits)
     newhpart(L, t, hbits);
+  t->sealed = 0;
   return t;
 }
 


### PR DESCRIPTION
This work-in-progress branch implements a new feature called "sealed tables."

### What

The branch introduces one new function:

```
jit.seal(mytable)
```

which marks a table as *sealed*.

The JIT compiles lookups into sealed tables specially: the lookup is only performed when the trace is recorded and then the value is inlined into the machine code. This makes the lookup practically free at runtime provided that the same table/value is being referenced each time. This condition is checked with a couple of cheap guards at runtime (you will get a side-trace if you mix sealed tables and keys on the same line of code.)

### Why

Broadly speaking I propose sealed tables as a "superpower" that is lacking in static compilers like GCC. We are able to take dynamic runtime values and compile them as constants.

The simple motivating use case is to replace the coding practice of using `local` declarations to cache functions in other modules. This is verbose and yucky. The modules could simply be sealed instead.

This means that instead of writing code like this:

```lua
local bit_band, bit_bor, bit_bxor = bit.band, bit.bor, bit.bxor
bit_band(bit_bor(1, 2), 3)
```

You can achieve the same performance by simply writing:

```lua
bit.band(bit.bor(1, 2), 3)
```

i.e. it allows you to skip the boilerplate without sacrificing performance.

The secondary use case is to be able to declare that the JIT should aggressively optimize certain data that is likely to be invariant. For example:

```lua
mymath = { pi = 3.14, square = function (x) return x*x end }
jit.seal(mymath)
mymath.square(mymath.pi)) -- Compiles to the constant 6.28 (no lookups & no arith)
```

which could be useful for having the JIT aggressively specialize machine code for an application's configuration data. (The application will need to flush the JIT and rerecord when the data changes.)

### Performance

Goals:

1. Let programmers write code that references globals even inside inner loops.
2. Eliminate lookup instructions (`HREFK`, `FLOAD`, etc) to relieve load on CPU backend.
3. Provide **redundancy** for loop optimization by reducing the performance gap between side-traces and loop-optimized root traces. This is key to making performance robust and predictable i.e. not too sensitive to specific optimizations that are themselves sensitive to programming style and workload. (That's meant as a shot at both loop optimization and allocation sinking.)

Testing strategy:

1. Pick a benchmark.
2. Rewrite it by removing all local-caching boilerplate.
3. Benchmark impact of sealed tables with and without loop optimization.

Preliminary results for MD5 benchmark:

![plot_zoom_png](https://user-images.githubusercontent.com/13791/34880417-a6c09af8-f7b0-11e7-91ac-da7bf3e9365f.png)

Interpretation:

- The standard `md5` benchmark with `local` boilerplate runs the same in both versions both with and without loop optimization.
- The modified `md5nolocal` benchmark is much faster when loop optimization is disabled and also somewhat faster when loop optimization is enabled.

The boilerplate removed in the modified version is:

```lua
local bit = require("bit")
local tobit, tohex, bnot = bit.tobit or bit.cast, bit.tohex, bit.bnot
local bor, band, bxor = bit.bor, bit.band, bit.bxor
local lshift, rshift, rol, bswap = bit.lshift, bit.rshift, bit.rol, bit.bswap
local byte, char, sub, rep = string.byte, string.char, string.sub, string.rep
```

This is consistent with the table sealing feature making it safe to "burn your boilerplate." Rock on!

### TODO

- [ ] Enforce the invariant that sealed tables are invariant for the lifetime of trace machine code. (Add a barrier on writes to sealed tables to flush the JIT.)
- [ ] Evaluate on my benchmarks.
- [ ] Evaluate on a real application.
- [ ] Nail down semantics (how to handle missing keys, metatables, etc.)
- [ ] Add a convenient interface such as `jit.sealall()` to make `require()` automatically seal loaded modules.

### Related work

@fsfod has prototyped a similar feature on his readonly_tables branch. This work has not been PR'd and reviewed anywhere yet as far as I know. It may represent the same approach to the problem (or even a better one.)

I have been streaming the development of this feature on YouTube: https://www.youtube.com/playlist?list=PLKZH0fVSEHj2mXfPmAYEAK982VIRQ5NcS

Some related past discussion: https://github.com/LuaJIT/LuaJIT/issues/248

cc @javierguerragiraldez who has expressed interest in this idea in the past.