### PR TITLE
Just use the default gcc instead of clang 4.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ build environment. You can use Nix to build/test/benchmark RaptorJIT
 with suitable versions of all dependencies provided.
 
 Note: Building with nix will be slow the first time because it
-downloads the exact reference versions of the toolchain (clang, etc)
+downloads the exact reference versions of the toolchain (gcc, etc)
 and all dependencies (glibc, etc). This is all cached for future
 builds.
 
@@ -97,7 +97,7 @@ $ nix-shell    # start sub-shell with pristine build environment in $PATH
 $ make
 ```
 
-... but make sure you have at least `make`, `clang`, and `luajit` in your `$PATH`.
+... but make sure you have at least `make`, `gcc`, and `luajit` in your `$PATH`.
 
 ### Run the benchmarks
 

--- a/raptorjit.nix
+++ b/raptorjit.nix
@@ -3,13 +3,14 @@
 { pkgs, source, version }:
 
 with pkgs;
-with llvmPackages_4.stdenv;  # Use clang 4.0
+with stdenv;
 
 mkDerivation rec {
   name = "raptorjit-${version}";
   inherit version;
   src = source;
   buildInputs = [ luajit ];  # LuaJIT to bootstrap DynASM
+  dontStrip = true;
   installPhase = ''
     mkdir -p $out/bin
     cp src/raptorjit $out/bin/raptorjit

--- a/src/Makefile
+++ b/src/Makefile
@@ -377,6 +377,10 @@ $(HOST_O): %.o: %.c
 	$(E) "HOSTCC    $@"
 	$(Q)$(HOST_CC) $(HOST_ACFLAGS) -c -o $@ $<
 
+$(DWARF_DWO): %.dwo: %.c
+	$(E) "CC(debug) $@"
+	$(Q)$(TARGET_CC) -g3 -fno-eliminate-unused-debug-types -gsplit-dwarf -c $<
+
 include Makefile.dep
 
 ##############################################################################


### PR DESCRIPTION
It was a bit of a flight of fancy to use a pinned version of clang.

This would make sense if we were really depending on hyper-specific behaviour of the C compiler, like some automatic SIMD parallization, but in reality we're not. So don't be fussy and just keep it simple.