### PR TITLE
shell.nix: Make 'nix-shell' command work as documented

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,2 @@
+(import ./default.nix {}).raptorjit
+


### PR DESCRIPTION
The README says that running 'nix-shell' should open a RaptorJIT build environment. The command actually needed was 'nix-shell -A raptorjit'. However, adding this shell.nix file makes 'nix-shell' do the right thing.

Resolves #158.