### PR TITLE
Use virtual instead of profile time for vmprofile

### DIFF
--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -88,11 +88,11 @@ static void start_timer(int interval)
   struct sigaction sa;
   tm.it_value.tv_sec = tm.it_interval.tv_sec = interval / 1000;
   tm.it_value.tv_usec = tm.it_interval.tv_usec = (interval % 1000) * 1000;
-  setitimer(ITIMER_PROF, &tm, NULL);
+  setitimer(ITIMER_VIRTUAL, &tm, NULL);
   sa.sa_flags = SA_SIGINFO | SA_RESTART;
   sa.sa_sigaction = vmprofile_signal;
   sigemptyset(&sa.sa_mask);
-  sigaction(SIGPROF, &sa, &state.oldsa);
+  sigaction(SIGVTALRM, &sa, &state.oldsa);
 }
 
 static void stop_timer()
@@ -100,8 +100,8 @@ static void stop_timer()
   struct itimerval tm;
   tm.it_value.tv_sec = tm.it_interval.tv_sec = 0;
   tm.it_value.tv_usec = tm.it_interval.tv_usec = 0;
-  setitimer(ITIMER_PROF, &tm, NULL);
-  sigaction(SIGPROF, NULL, &state.oldsa);
+  setitimer(ITIMER_VIRTUAL, &tm, NULL);
+  sigaction(SIGVTALRM, NULL, &state.oldsa);
 }
 
 /* -- State that the application can manage via FFI ----------------------- */


### PR DESCRIPTION
This is a fix by @takikawa cherry-picked from the Snabb branch of RaptorJIT. It switches VMProfile from sampling based on wall-clock time to sampling based on userspace-CPU-time. This prevents profiler signals from interrupting system calls and it also keeps the profiler data focused on time spent in RaptorJIT code itself. (When you are concerned about time spent in system calls then it is better to use a separate system profiler like `perf`.)

----

Avoids infinite looping due to system call restarts triggered by SIGPROF handling.

Virtual time doesn't account for time spent in the kernel handling system calls but Snabb tries to avoid spending time in system calls.

(cherry picked from commit c4681a6c59f705fc49368bc1ae8fdc3fbbeee685)