### PR TITLE
Minimal rebranding from LuaJIT -> RaptorJIT

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 ##############################################################################
-# LuaJIT Makefile. Requires GNU Make.
+# RaptorJIT Makefile. Requires GNU Make.
 #
 # Please read doc/install.html before changing any variables!
 #

--- a/src/host/buildvm.c
+++ b/src/host/buildvm.c
@@ -372,7 +372,6 @@ static void usage(void)
 {
   int i;
   fprintf(stderr, LUAJIT_VERSION " VM builder.\n");
-  fprintf(stderr, LUAJIT_COPYRIGHT ", " LUAJIT_URL "\n");
   fprintf(stderr, "Target architecture: " LJ_ARCH_NAME "\n\n");
   fprintf(stderr, "Usage: buildvm -m mode [-o outfile] [infiles...]\n\n");
   fprintf(stderr, "Available modes:\n");

--- a/src/jit/bc.lua
+++ b/src/jit/bc.lua
@@ -41,7 +41,7 @@
 
 -- Cache some library functions and objects.
 local jit = require("jit")
-assert(jit.version_num == 20100, "LuaJIT core/library version mismatch")
+assert(jit.version_num == 10000, "LuaJIT core/library version mismatch")
 local jutil = require("jit.util")
 local vmdef = require("jit.vmdef")
 local bit = require("bit")

--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -11,7 +11,7 @@
 ------------------------------------------------------------------------------
 
 local jit = require("jit")
-assert(jit.version_num == 20100, "LuaJIT core/library version mismatch")
+assert(jit.version_num == 10000, "LuaJIT core/library version mismatch")
 local bit = require("bit")
 
 -- Symbol name prefix for LuaJIT bytecode.

--- a/src/luajit.c
+++ b/src/luajit.c
@@ -55,8 +55,8 @@ static void print_usage(void)
   "  -e chunk  Execute string " LUA_QL("chunk") ".\n"
   "  -l name   Require library " LUA_QL("name") ".\n"
   "  -b ...    Save or list bytecode.\n"
-  "  -j cmd    Perform LuaJIT control command.\n"
-  "  -O[opt]   Control LuaJIT optimizations.\n"
+  "  -j cmd    Perform RaptorJIT control command.\n"
+  "  -O[opt]   Control RaptorJIT optimizations.\n"
   "  -i        Enter interactive mode after executing " LUA_QL("script") ".\n"
   "  -p file   Enable trace profiling to a VMProfile file.\n"
   "  -v        Show version information.\n"
@@ -115,7 +115,7 @@ static int docall(lua_State *L, int narg, int clear)
 
 static void print_version(void)
 {
-  fputs(LUAJIT_VERSION " -- " LUAJIT_COPYRIGHT ". " LUAJIT_URL "\n", stdout);
+  fputs(LUAJIT_VERSION " -- " LUAJIT_URL "\n", stdout);
 }
 
 static void print_jit_status(lua_State *L)

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -30,11 +30,11 @@
 
 #include "lua.h"
 
-#define LUAJIT_VERSION		"LuaJIT 2.1.0-beta2"
-#define LUAJIT_VERSION_NUM	20100  /* Version 2.1.0 = 02.01.00. */
+#define LUAJIT_VERSION		"RaptorJIT 1.0.0-alpha1"
+#define LUAJIT_VERSION_NUM	100000  /* Version 1.0.0 = 01.00.00. */
 #define LUAJIT_VERSION_SYM	luaJIT_version_2_1_0_beta2
-#define LUAJIT_COPYRIGHT	"Copyright (C) 2005-2017 Mike Pall"
-#define LUAJIT_URL		"http://luajit.org/"
+
+#define LUAJIT_URL		"http://github.com/raptorjit/raptorjit"
 
 /* Modes for luaJIT_setmode. */
 #define LUAJIT_MODE_MASK	0x00ff


### PR DESCRIPTION
Make obvious printouts declare the project to be "RaptorJIT 1.0.0" rather than "LuaJIT 2.1.0".

Remove copyright printout on startup. It's hard to do justice to the full story in so few characters.