### PR TITLE
Fix allocation/deallocation of T->szirmcode

### DIFF
--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -1995,7 +1995,7 @@ void lj_asm_trace(jit_State *J, GCtrace *T)
   /* Setup initial state. Copy some fields to reduce indirections. */
   as->J = J;
   as->T = T;
-  J->curfinal = lj_trace_alloc(J->L, T);  /* This copies the IR, too. */
+  J->curfinal = lj_trace_alloc(J->L, T);  /* Copies IR and moves szirmcode. */
   as->flags = J->flags;
   as->loopref = J->loopref;
   as->realign = NULL;

--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -2003,8 +2003,9 @@ void lj_asm_trace(jit_State *J, GCtrace *T)
   as->parent = J->parent ? traceref(J, J->parent) : NULL;
 
   /* Initialize mcode size of IR instructions array. */
-  T->szirmcode = lj_mem_new(J->L, (T->nins + 1) * sizeof(*T->szirmcode));
-  memset(T->szirmcode, 0, (T->nins + 1) * sizeof(*T->szirmcode));
+  /* +2 extra spaces for the last instruction and the trace header at [0]. */
+  T->szirmcode = lj_mem_new(J->L, (T->nins + 2 - REF_BIAS) * sizeof(*T->szirmcode));
+  memset(T->szirmcode, 0, (T->nins + 2 - REF_BIAS) * sizeof(*T->szirmcode));
 
   /* Reserve MCode memory. */
   as->mctop = origtop = lj_mcode_reserve(J, &as->mcbot);

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -136,6 +136,7 @@ void lj_trace_free(global_State *g, GCtrace *T)
     lj_gdbjit_deltrace(J, T);
     setgcrefnull(J->trace[T->traceno]);
   }
+  lj_mem_free(g, T->szirmcode, (T->nins + 2 - REF_BIAS) * sizeof(*T->szirmcode));
   lj_mem_free(g, T,
     ((sizeof(GCtrace)+7)&~7) + (T->nins-T->nk)*sizeof(IRIns) +
     T->nsnap*sizeof(SnapShot) + T->nsnapmap*sizeof(SnapEntry));

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -99,6 +99,7 @@ GCtrace * lj_trace_alloc(lua_State *L, GCtrace *T)
   T2->nk = T->nk;
   T2->nsnap = T->nsnap;
   T2->nsnapmap = T->nsnapmap;
+  T2->szirmcode = T->szirmcode;
   memcpy(p, T->ir + T->nk, szins);
   return T2;
 }


### PR DESCRIPTION
This array was allocated too large (padded to REF_BASE) and was not freed.

This branch crashes with segfault on the `fasta` benchmark but I am not sure if this is a consequence of this change yet.