### PR TITLE
lj_ctype.c: Detect loops in ctype_repr()

### DIFF
--- a/src/lj_ctype.c
+++ b/src/lj_ctype.c
@@ -447,6 +447,7 @@ static void ctype_repr(CTRepr *ctr, CTypeID id)
   for (;;) {
     CTInfo info = ct->info;
     CTSize size = ct->size;
+    CType *newct;
     switch (ctype_type(info)) {
     case CT_NUM:
       if ((info & CTF_BOOL)) {
@@ -532,7 +533,13 @@ static void ctype_repr(CTRepr *ctr, CTypeID id)
       ctr->ok = 0;
       return;
     }
-    ct = ctype_get(ctr->cts, ctype_cid(info));
+    newct = ctype_get(ctr->cts, ctype_cid(info));
+    /* Detect ctypes that are not OK due to looping. */
+    if (newct == ct) {
+      ctr->ok = 0;
+      return;
+    }
+    ct = newct;
   }
 }
 


### PR DESCRIPTION
This is a potential fix for #180 where trying to print certain ctypes puts the runtime system into an infinite loop.

I do not honestly understand the phenomenon of ctypes being "not OK" for printing (`ct->ok=0`) and so for the moment I am only adding some defensive programming to try and ensure that these types print as `?` instead of causing undefined behaviour like crashes and hangs.