### PR TITLE
default.nix: Test with -DLUA_USE_ASSERT and -Werror

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ NODOTABIVER= 51
 # to slow down the C part by not omitting it. Debugging, tracebacks and
 # unwinding are not affected -- the assembler part has frame unwind
 # information and GCC emits it where needed (x64) or with -g (see CCDEBUG).
-CCOPT= -O2 -fomit-frame-pointer -Werror
+CCOPT= -O2 -fomit-frame-pointer
 # Use this if you want to generate a smaller binary (but it's slower):
 #CCOPT= -Os -fomit-frame-pointer
 # Note: it's no longer recommended to use -O3 with GCC 4.x.


### PR DESCRIPTION
The standard test cases are all executed with VMs build with `-DLUA_USE_ASSERT`. If the check argument is specified then the VM is also built with `-Werror` to check for (fail on) compiler warnings.