### PR TITLE
Reinstate memory leak protection & make it work

### DIFF
--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -1995,17 +1995,12 @@ void lj_asm_trace(jit_State *J, GCtrace *T)
   /* Setup initial state. Copy some fields to reduce indirections. */
   as->J = J;
   as->T = T;
-  J->curfinal = lj_trace_alloc(J->L, T);  /* Copies IR and moves szirmcode. */
+  J->curfinal = lj_trace_alloc(J->L, T);
   as->flags = J->flags;
   as->loopref = J->loopref;
   as->realign = NULL;
   as->loopinv = 0;
   as->parent = J->parent ? traceref(J, J->parent) : NULL;
-
-  /* Initialize mcode size of IR instructions array. */
-  /* +2 extra spaces for the last instruction and the trace header at [0]. */
-  T->szirmcode = lj_mem_new(J->L, (T->nins + 2 - REF_BIAS) * sizeof(*T->szirmcode));
-  memset(T->szirmcode, 0, (T->nins + 2 - REF_BIAS) * sizeof(*T->szirmcode));
 
   /* Reserve MCode memory. */
   as->mctop = origtop = lj_mcode_reserve(J, &as->mcbot);
@@ -2075,7 +2070,8 @@ void lj_asm_trace(jit_State *J, GCtrace *T)
       RA_DBG_REF();
       checkmclim(as);
       asm_ir(as, ir);
-      T->szirmcode[as->curins - REF_BIAS] = (uint16_t)((intptr_t)end - (intptr_t)as->mcp);
+      lua_assert(as->curins-REF_BIAS < J->curfinal->nszirmcode);
+      J->curfinal->szirmcode[as->curins-REF_BIAS] = (uint16_t)(end - as->mcp);
     }
 
     firstins = as->mcp;	/* MCode assembled for IR instructions. */
@@ -2105,7 +2101,7 @@ void lj_asm_trace(jit_State *J, GCtrace *T)
 	     (T->nins - as->orignins) * sizeof(IRIns));  /* Copy RENAMEs. */
       T->nins = J->curfinal->nins;
       /* Log size of trace head */
-      T->szirmcode[0] = (uint16_t)((intptr_t)firstins - (intptr_t)as->mcp);
+      J->curfinal->szirmcode[0] = (uint16_t)((intptr_t)firstins - (intptr_t)as->mcp);
       break;  /* Done. */
     }
 
@@ -2113,6 +2109,7 @@ void lj_asm_trace(jit_State *J, GCtrace *T)
     lj_trace_free(J2G(J), J->curfinal);
     J->curfinal = NULL;  /* In case lj_trace_alloc() OOMs. */
     J->curfinal = lj_trace_alloc(J->L, T);
+    lua_assert(J->curfinal->nszirmcode);
     as->realign = NULL;
   }
 

--- a/src/lj_auditlog.c
+++ b/src/lj_auditlog.c
@@ -173,7 +173,7 @@ static void log_GCtrace(GCtrace *T)
   log_mem("SnapShot[]", T->snap, T->nsnap * sizeof(*T->snap));
   log_mem("SnapEntry[]", T->snapmap, T->nsnapmap * sizeof(*T->snapmap));
   log_mem("IRIns[]", &T->ir[T->nk], (T->nins - T->nk + 1) * sizeof(IRIns));
-  log_mem("uint16_t[]", T->szirmcode, (T->nins - REF_BIAS - 1) * sizeof(uint16_t));
+  log_mem("uint16_t[]", T->szirmcode, T->nszirmcode * sizeof(uint16_t));
   for (ref = T->nk; ref < REF_TRUE; ref++) {
     IRIns *ir = &T->ir[ref];
     if (ir->o == IR_KGC) {

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -192,6 +192,7 @@ typedef struct GCtrace {
   MSize szmcode;	/* Size of machine code. */
   MCode *mcode;		/* Start of machine code. */
   MSize mcloop;		/* Offset of loop start in machine code. */
+  uint16_t nszirmcode;	/* Number of elements in szirmcode array. */
   uint16_t *szirmcode;  /* Bytes of mcode for each IR instruction (array.) */
   uint16_t nchild;	/* Number of child traces (root trace only). */
   uint16_t spadjust;	/* Stack pointer adjustment (offset in bytes). */

--- a/src/lj_state.c
+++ b/src/lj_state.c
@@ -173,10 +173,7 @@ static void close_state(lua_State *L)
   lj_mem_free(g, J->snapbuf, sizeof(SnapShot)*65536);
   lj_mem_free(g, J->irbuf, 65536*sizeof(IRIns));
   lj_mem_free(g, J->trace, TRACE_MAX * sizeof(GCRef *));
-#if 0
-  /* XXX Fix deallocation so that this assertion succeeds. */
   lua_assert(g->gc.total == sizeof(GG_State));
-#endif
 #ifndef LUAJIT_USE_SYSMALLOC
   if (g->allocf == lj_alloc_f)
     lj_alloc_destroy(g->allocd);


### PR DESCRIPTION
Fix a memory leak in trace debug information. Re-enable the assertion that automatically "balances the books" to detect memory leaks by comparing bytes allocated to bytes freed.

Resolves #185.