### PR TITLE
lj_ctype.c: Detect bad ctypeid without failing lua_assert

### DIFF
--- a/src/lj_ctype.c
+++ b/src/lj_ctype.c
@@ -533,6 +533,10 @@ static void ctype_repr(CTRepr *ctr, CTypeID id)
       ctr->ok = 0;
       return;
     }
+    if (ctype_cid(info) == 0) {
+      ctr->ok = 0;
+      return;
+    }
     newct = ctype_get(ctr->cts, ctype_cid(info));
     /* Detect ctypes that are not OK due to looping. */
     if (newct == ct) {


### PR DESCRIPTION
Fixes an obscure assertion failure that can occur when logging ctype names to the auditlog (when RaptorJIT is compiled with LUA_USE_ASSERT.)