### PR TITLE
Add PROFESSIONAL-SUPPORT.md list of service providers

### DIFF
--- a/PROFESSIONAL-SUPPORT.md
+++ b/PROFESSIONAL-SUPPORT.md
@@ -1,0 +1,10 @@
+Professional support is available to help you use RaptorJIT
+successfully. You can contact the parties listed below if you need
+help to design your application; to understand the compiler and the
+tools; to fix bugs and optimize code; to maintain a port to a new
+platform; etc.
+
+Links in alphabetical order with one-sentence summaries:
+
+- [Snabb Solutions](https://snabb.solutions/) offers consulting and standard support agreements for RaptorJIT and related projects.
+


### PR DESCRIPTION
RaptorJIT users need to know that there is professional support available if and when they need it. This is to reduce the risks associated with starting new projects (e.g. missing deadlines due to learning curve) and to reduce the costs of maintaining these applications (e.g. having in-house JIT internals gurus who need to be hired/trained/retained/replaced/etc over time.)

Having a set of service providers of diverse capacity/speciality/locale would be a major positive for the project so please don't be shy about adding your name to the list (person or company, in alphabetical order) if you want people to consider contacting you when they are looking for support.

cc @wingo @eugeneia @fsfod @agladysh @corsix.