### PR TITLE
src/Makefile: Fix unwanted dynamic linkage of dwarf debug info

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -390,7 +390,7 @@ $(DWARF_DWO): %.dwo: %.c
 lj_dwarf_dwo.o lj_dwarf_dwo_dyn.o: $(DWARF_DWO)
 	$(E) "EMBED     $@"
 	$(Q)$(LD) -r -b binary -o $@ $<
-	$(Q)$(LD) -shared -b binary -o $(@:.o=_dyn.o) $<
+	$(Q)$(LD) -b binary -o $(@:.o=_dyn.o) $<
 
 include Makefile.dep
 


### PR DESCRIPTION
Fix a bug where lj_dwarf_dwo_dyn.o was built as a shared object and caused linkage problems for libraptorjit.so.

Hopefully resolves #216.
