### PR TITLE
Compare hash value when interning strings

### DIFF
--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -130,7 +130,7 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
   o = gcref(g->strhash[h & g->strmask]);
   while (o != NULL) {
     GCstr *sx = gco2str(o);
-    if (sx->len == len && memcmp(str, strdata(sx), len) == 0) {
+    if (sx->hash == h && sx->len == len && memcmp(str, strdata(sx), len) == 0) {
       /* Resurrect if dead. Can only happen with fixstring() (keywords). */
       if (isdead(g, o)) flipwhite(o);
       return sx;  /* Return existing string. */


### PR DESCRIPTION
Merge luajit/luajit#243 into RaptorJIT.

This change makes an explicit comparison of the hash value when comparing strings for the purposes of interning. This takes additional relevant information into account since the strings being searched are only known to have a partial hash value match.