### PR TITLE
Fold 64-bit modulus

### DIFF
--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -1356,6 +1356,19 @@ LJFOLDF(simplify_intmod_k)
   return NEXTFOLD;
 }
 
+LJFOLD(MOD any KINT64)
+LJFOLDF(simplify_intmod_k64)
+{
+  uint64_t k = ir_kint64(fright)->u64;
+  lua_assert(k != 0);
+  if (k > 0 && (k & (k-1)) == 0) {  /* i % (2^k) ==> i & (2^k-1) */
+    fins->o = IR_BAND;
+    fins->op2 = (IRRef1)lj_ir_kint64(J, (int64_t)k-1);
+    return RETRYFOLD;
+  }
+  return NEXTFOLD;
+}
+
 LJFOLD(MOD KINT any)
 LJFOLDF(simplify_intmod_kleft)
 {


### PR DESCRIPTION
So, here's my initial attempt at fixing #234 for powers of two by copy/pasting code for 32-bit math. I would like to generalise this to emit direct IR for all modulus operations instead of emitting a call to the runtime before it gets merged, but for now let's see what others think.

I wrote a smoke test for modulus in the general case for LuaJIT (I think Luke can convert this to RaptorJIT equivalent):

```lua
-- SPDX-License-Identifier: CC0-1.0
-- Test for modulus optimisation by Dan Ravensloft.
--
-- Fermat's little theorem states that if p is a prime number, then for any integer a, the number a^p − a is an integer multiple of p.
local ffi = require("ffi")

-- This is not the most efficient algorithm, but that's okay because we're trying to stress the modulus operation.
local function modular_exp(ctype, num, exponent, modulus)
    exponent = tonumber(exponent) - 1
    local result = ffi.cast(ctype, 1)
    for i = 0, exponent do
        result = (result * num) % modulus
    end
    return result
end

-- Run the Fermat test on 1000 random integers
local function fermat_test(ctype, possible_prime)
    for i = 1, 1000 do
        local n = ffi.cast(ctype, math.random(2^32))
        local result = modular_exp(ctype, n, possible_prime, possible_prime)
        if result ~= n then
            return false
        end
    end
end

local test_type = "int64_t"

for i = 1, 1000 do
    fermat_test(test_type, ffi.cast(test_type, i))
end
```

If you run `luajit -jdump modulus_test.lua | grep lj_carith && echo "Fail" || echo "Success"`, you will currently get a failure because a call to the runtime is emitted. I'd like to merge this when the smoke test returns "Success".