### PR TITLE
Fix unsinking of 64-bit pointers 

### DIFF
--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -542,6 +542,10 @@ typedef union IRIns {
   TValue tv;		/* TValue constant (overlaps entire slot). */
 } IRIns;
 
+#define ir_isk64(ir)	 ((ir)->o == IR_KNUM || (ir)->o == IR_KINT64 || \
+                          (ir)->o == IR_KGC ||                          \
+                          (ir)->o == IR_KPTR || (ir)->o == IR_KKPTR)
+
 #define ir_kgc(ir)	check_exp((ir)->o == IR_KGC, gcref((ir)[1].gcr))
 #define ir_kstr(ir)	(gco2str(ir_kgc((ir))))
 #define ir_ktab(ir)	(gco2tab(ir_kgc((ir))))
@@ -549,11 +553,7 @@ typedef union IRIns {
 #define ir_kcdata(ir)	(gco2cd(ir_kgc((ir))))
 #define ir_knum(ir)	check_exp((ir)->o == IR_KNUM, &(ir)[1].tv)
 #define ir_kint64(ir)	check_exp((ir)->o == IR_KINT64, &(ir)[1].tv)
-#define ir_k64(ir) \
-  check_exp((ir)->o == IR_KNUM || (ir)->o == IR_KINT64 || \
-	     (ir)->o == IR_KGC || \
-	      (ir)->o == IR_KPTR || (ir)->o == IR_KKPTR, \
-	    &(ir)[1].tv)
+#define ir_k64(ir)	check_exp(ir_isk64(ir), &(ir)[1].tv)
 #define ir_kptr(ir) \
   check_exp((ir)->o == IR_KPTR || (ir)->o == IR_KKPTR, \
     mref((ir)[1].ptr, void))

--- a/src/lj_snap.c
+++ b/src/lj_snap.c
@@ -608,7 +608,7 @@ static void snap_restoredata(GCtrace *T, ExitState *ex,
   int32_t *src;
   uint64_t tmp;
   if (irref_isk(ref)) {
-    if (ir->o == IR_KNUM || ir->o == IR_KINT64) {
+    if (ir_isk64(ir)) {
       src = (int32_t *)&ir[1];
     } else if (sz == 8) {
       tmp = (uint64_t)(uint32_t)ir->i;

--- a/testsuite/test/trace/index
+++ b/testsuite/test/trace/index
@@ -5,3 +5,4 @@ gc64_slot_revival.lua
 phi
 snap.lua
 stitch.lua
+unsink.lua

--- a/testsuite/test/trace/unsink.lua
+++ b/testsuite/test/trace/unsink.lua
@@ -1,0 +1,39 @@
+local ffi = require("ffi")
+
+-- Unsinking is what happens when a "sunk" allocation needs to be
+-- performed at trace exit time. The JIT has optimized away the
+-- allocation within the trace machine code but when we exit back to
+-- the interpeter the fully allocated value can be required.
+--
+-- (Strictly speaking unsinking is what happens when a sunk allocation
+-- is referenced by the snapshot of a taken trace exit and the Lua
+-- stack needs to be reconstructed for the interpreter to use.)
+
+local array = ffi.new("struct { int x; } [1]")
+
+do --- unsink constant pointer
+
+   -- This test forces the VM to unsink a pointer that was constructed
+   -- from a constant. The IR will include a 'cnewi' instruction to
+   -- allocate an FFI pointer object, the pointer value will be an IR
+   -- constant, the allocation will be sunk, and the allocation will
+   -- at some point be "unsunk" due to a reference in the snapshot for
+   -- a taken exit.
+
+   -- Note: JIT will recognize <array> as a "singleton" and allow its
+   -- address to be inlined ("constified") instead of looking up the
+   -- upvalue at runtime.
+
+   local function fn (i)
+      local struct = array[0]   -- Load pointer that the JIT will constify.
+      if i == 1000 then end     -- Force trace exit when i==1000.
+      struct.x = 0              -- Ensure that 'struct' is live after exit.
+   end
+
+   -- Loop over the function to make it compile and take a trace exit
+   -- during the final iteration.
+   for i = 1, 1000 do
+      fn(i)
+   end
+end
+


### PR DESCRIPTION
Fix a bug where 64-bit pointer values would be mangled during unsinking. The unsinking code was not using the correct layout for GC64 IR constants (value in adjacent slot) for this case.

Fixed in an intense debugging session together with @thibaultcha and @dndx.

This branch includes the test from #245 and makes it pass.